### PR TITLE
Change semaphore name from xFATSemaphore to sdCardSemaphore

### DIFF
--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -241,11 +241,11 @@ void beginSD()
     }
 
     //Setup FAT file access semaphore
-    if (xFATSemaphore == NULL)
+    if (sdCardSemaphore == NULL)
     {
-      xFATSemaphore = xSemaphoreCreateMutex();
-      if (xFATSemaphore != NULL)
-        xSemaphoreGive(xFATSemaphore);  //Make the file system available for use
+      sdCardSemaphore = xSemaphoreCreateMutex();
+      if (sdCardSemaphore != NULL)
+        xSemaphoreGive(sdCardSemaphore);  //Make the file system available for use
     }
 
     if (createTestFile() == false)

--- a/Firmware/RTK_Surveyor/Buttons.ino
+++ b/Firmware/RTK_Surveyor/Buttons.ino
@@ -31,13 +31,13 @@ void powerDown(bool displayInfo)
   {
     //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile()
     //Wait up to 1000ms
-    if (xSemaphoreTake(xFATSemaphore, 1000 / portTICK_PERIOD_MS) == pdPASS)
+    if (xSemaphoreTake(sdCardSemaphore, 1000 / portTICK_PERIOD_MS) == pdPASS)
     {
       //Close down file system
       ubxFile.sync();
       ubxFile.close();
-      //xSemaphoreGive(xFATSemaphore); //Do not release semaphore
-    } //End xFATSemaphore
+      //xSemaphoreGive(sdCardSemaphore); //Do not release semaphore
+    } //End sdCardSemaphore
 
     online.logging = false;
   }

--- a/Firmware/RTK_Surveyor/Buttons.ino
+++ b/Firmware/RTK_Surveyor/Buttons.ino
@@ -38,6 +38,10 @@ void powerDown(bool displayInfo)
       ubxFile.close();
       //xSemaphoreGive(sdCardSemaphore); //Do not release semaphore
     } //End sdCardSemaphore
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
 
     online.logging = false;
   }

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -86,6 +86,10 @@ void recordSystemSettingsToFileSD(char *fileName)
 
       xSemaphoreGive(sdCardSemaphore);
     }
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
   }
 }
 
@@ -286,6 +290,10 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
       }
 
     } //End Semaphore check
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
   } //End SD online
 
   log_d("Config file read failed: SD offline");

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -62,7 +62,7 @@ void recordSystemSettingsToFileSD(char *fileName)
   if (online.microSD == true)
   {
     //Attempt to write to file system. This avoids collisions with file writing from other functions like updateLogs()
-    if (xSemaphoreTake(xFATSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
     {
       if (sd.exists(fileName))
         sd.remove(fileName);
@@ -84,7 +84,7 @@ void recordSystemSettingsToFileSD(char *fileName)
 
       log_d("Settings recorded to SD: %s", fileName);
 
-      xSemaphoreGive(xFATSemaphore);
+      xSemaphoreGive(sdCardSemaphore);
     }
   }
 }
@@ -226,7 +226,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
   if (online.microSD == true)
   {
     //Attempt to access file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
-    if (xSemaphoreTake(xFATSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
     {
       if (sd.exists(fileName))
       {
@@ -234,7 +234,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
         if (settingsFile.open(fileName, O_READ) == false)
         {
           Serial.println(F("Failed to open settings file"));
-          xSemaphoreGive(xFATSemaphore);
+          xSemaphoreGive(sdCardSemaphore);
           return (false);
         }
 
@@ -255,7 +255,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
             {
               //If we can't read the first line of the settings file, give up
               Serial.println(F("Giving up on settings file"));
-              xSemaphoreGive(xFATSemaphore);
+              xSemaphoreGive(sdCardSemaphore);
               return (false);
             }
           }
@@ -265,7 +265,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
             {
               //If we can't read the first line of the settings file, give up
               Serial.println(F("Giving up on settings file"));
-              xSemaphoreGive(xFATSemaphore);
+              xSemaphoreGive(sdCardSemaphore);
               return (false);
             }
           }
@@ -275,13 +275,13 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
 
         //Serial.println(F("Config file read complete"));
         settingsFile.close();
-        xSemaphoreGive(xFATSemaphore);
+        xSemaphoreGive(sdCardSemaphore);
         return (true);
       }
       else
       {
         log_d("File %s not found", fileName);
-        xSemaphoreGive(xFATSemaphore);
+        xSemaphoreGive(sdCardSemaphore);
         return (false);
       }
 

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -570,6 +570,10 @@ void updateLogs()
       online.logging = false;
       xSemaphoreGive(sdCardSemaphore); //Release semaphore
     }
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
   }
   else if (online.logging == true && settings.enableLogging == true && (systemTime_minutes - startCurrentLogTime_minutes) >= settings.maxLogLength_minutes)
   {
@@ -580,6 +584,10 @@ void updateLogs()
       ubxFile.close();
       online.logging = false;
       xSemaphoreGive(sdCardSemaphore); //Release semaphore
+    }
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
 
@@ -608,7 +616,7 @@ void updateLogs()
       } //End sdCardSemaphore
       else
       {
-        log_d("Semaphore failed to yield");
+        Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
       }
     }
 
@@ -631,6 +639,10 @@ void updateLogs()
         xSemaphoreGive(sdCardSemaphore);
         newEventToRecord = false;
       }
+      else
+      {
+        Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      }
     }
 
     //Report file sizes to show recording is working
@@ -644,6 +656,10 @@ void updateLogs()
         fileSize = ubxFile.fileSize();
 
         xSemaphoreGive(sdCardSemaphore);
+      }
+      else
+      {
+        Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
       }
 
       if (fileSize > 0)

--- a/Firmware/RTK_Surveyor/System.ino
+++ b/Firmware/RTK_Surveyor/System.ino
@@ -576,6 +576,10 @@ bool createTestFile()
     }
     xSemaphoreGive(sdCardSemaphore);
   }
+  else
+  {
+    Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+  }
 
   return (false);
 }

--- a/Firmware/RTK_Surveyor/System.ino
+++ b/Firmware/RTK_Surveyor/System.ino
@@ -556,14 +556,14 @@ bool createTestFile()
   SdFile testFile;
   char testFileName[40] = "testfile.txt";
 
-  if (xFATSemaphore == NULL)
+  if (sdCardSemaphore == NULL)
   {
-    log_d("xFATSemaphore is Null");
+    log_d("sdCardSemaphore is Null");
     return (false);
   }
 
   //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
-  if (xSemaphoreTake(xFATSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
+  if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
   {
     if (testFile.open(testFileName, O_CREAT | O_APPEND | O_WRITE) == true)
     {
@@ -571,10 +571,10 @@ bool createTestFile()
 
       if (sd.exists(testFileName))
         sd.remove(testFileName);
-      xSemaphoreGive(xFATSemaphore);
+      xSemaphoreGive(sdCardSemaphore);
       return (true);
     }
-    xSemaphoreGive(xFATSemaphore);
+    xSemaphoreGive(sdCardSemaphore);
   }
 
   return (false);

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -75,12 +75,12 @@ void F9PSerialReadTask(void *e)
         if ((systemTime_minutes - startLogTime_minutes) < settings.maxLogTime_minutes)
         {
           //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile()
-          if (xSemaphoreTake(xFATSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
+          if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
           {
             ubxFile.write(rBuffer, s);
 
-            xSemaphoreGive(xFATSemaphore);
-          } //End xFATSemaphore
+            xSemaphoreGive(sdCardSemaphore);
+          } //End sdCardSemaphore
           else
           {
             log_d("Semaphore failed to yield");

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -83,7 +83,7 @@ void F9PSerialReadTask(void *e)
           } //End sdCardSemaphore
           else
           {
-            log_d("Semaphore failed to yield");
+            Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
           }
         } //End maxLogTime
       } //End logging

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -94,7 +94,10 @@ void scanForFirmware()
 
       xSemaphoreGive(sdCardSemaphore);
     }
-
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
   }
 }
 

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -52,7 +52,7 @@ void scanForFirmware()
   {
     //Attempt to access file system. This avoids collisions with file writing in F9PSerialReadTask()
     //Wait up to 5s, this is important
-    if (xSemaphoreTake(xFATSemaphore, 5000 / portTICK_PERIOD_MS) == pdPASS)
+    if (xSemaphoreTake(sdCardSemaphore, 5000 / portTICK_PERIOD_MS) == pdPASS)
     {
       //Count available binaries
       SdFile tempFile;
@@ -92,7 +92,7 @@ void scanForFirmware()
         tempFile.close();
       }
 
-      xSemaphoreGive(xFATSemaphore);
+      xSemaphoreGive(sdCardSemaphore);
     }
 
   }

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -219,12 +219,12 @@ void factoryReset()
   //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
   if (settings.enableSD && online.microSD)
   {
-    if (xSemaphoreTake(xFATSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
     {
       //Remove this specific settings file. Don't remove the other profiles.
       sd.remove(settingsFileName);
-      xSemaphoreGive(xFATSemaphore);
-    } //End xFATSemaphore
+      xSemaphoreGive(sdCardSemaphore);
+    } //End sdCardSemaphore
   }
 
   if (online.gnss == true)

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -225,6 +225,10 @@ void factoryReset()
       sd.remove(settingsFileName);
       xSemaphoreGive(sdCardSemaphore);
     } //End sdCardSemaphore
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
   }
 
   if (online.gnss == true)

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -480,6 +480,10 @@ bool findLastLog(char *lastLogName)
 
       xSemaphoreGive(sdCardSemaphore);
     }
+    else
+    {
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+    }
   }
 
   return (foundAFile);

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -345,7 +345,7 @@ void beginLogging()
       }
 
       //Attempt to write to file system. This avoids collisions with file writing in F9PSerialReadTask()
-      if (xSemaphoreTake(xFATSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+      if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
       {
         // O_CREAT - create the file if it does not exist
         // O_APPEND - seek to the end of the file prior to each write
@@ -354,7 +354,7 @@ void beginLogging()
         {
           Serial.printf("Failed to create GNSS UBX data file: %s\n\r", fileName);
           online.logging = false;
-          xSemaphoreGive(xFATSemaphore);
+          xSemaphoreGive(sdCardSemaphore);
           return;
         }
 
@@ -405,7 +405,7 @@ void beginLogging()
           Serial.println(F("Appending last available log"));
         }
 
-        xSemaphoreGive(xFATSemaphore);
+        xSemaphoreGive(sdCardSemaphore);
       }
       else
       {
@@ -448,7 +448,7 @@ bool findLastLog(char *lastLogName)
   {
     //Attempt to access file system. This avoids collisions with file writing in F9PSerialReadTask()
     //Wait up to 5s, this is important
-    if (xSemaphoreTake(xFATSemaphore, 5000 / portTICK_PERIOD_MS) == pdPASS)
+    if (xSemaphoreTake(sdCardSemaphore, 5000 / portTICK_PERIOD_MS) == pdPASS)
     {
       //Count available binaries
       SdFile tempFile;
@@ -478,7 +478,7 @@ bool findLastLog(char *lastLogName)
         tempFile.close();
       }
 
-      xSemaphoreGive(xFATSemaphore);
+      xSemaphoreGive(sdCardSemaphore);
     }
   }
 

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -133,6 +133,10 @@ void menuSystem()
 
         xSemaphoreGive(sdCardSemaphore);
       }
+      else
+      {
+        Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      }
     }
     else if (incoming == 'x')
       break;

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -126,12 +126,12 @@ void menuSystem()
     else if (incoming == 'f' && settings.enableSD == true && online.microSD == true)
     {
       //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
-      if (xSemaphoreTake(xFATSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+      if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
       {
         Serial.println(F("Files found (date time size name):\n\r"));
         sd.ls(LS_R | LS_DATE | LS_SIZE);
 
-        xSemaphoreGive(xFATSemaphore);
+        xSemaphoreGive(sdCardSemaphore);
       }
     }
     else if (incoming == 'x')
@@ -290,7 +290,7 @@ void menuDebug()
     else if (incoming == 'r')
     {
       recordSystemSettings();
-      
+
       ESP.restart();
     }
     else if (incoming == 't')


### PR DESCRIPTION
The semaphore is protecting access to the SPI controller used to access
the SD card.  Any operations to the SD card need to be protected by this
semaphore.