### PR TITLE
Dynamically mount and dismount the microSD Card

### DIFF
--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -194,7 +194,7 @@ void beginSD()
     else if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) != pdPASS)
     {
       //This is OK since a retry will occur next loop
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      log_d("sdCardSemaphore failed to yield, Begin.ino line %d\r\n", __LINE__);
       break;
     }
     gotSemaphore = true;

--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -273,6 +273,24 @@ void beginSD()
     xSemaphoreGive(sdCardSemaphore);  //Make the file system available for use
 }
 
+void endSD(bool alreadyHaveSemaphore, bool releaseSemaphore)
+{
+  //Disable logging
+  endLogging(alreadyHaveSemaphore, false);
+
+  //Done with the SD card
+  if (online.microSD)
+  {
+    sd.end();
+    online.microSD = false;
+    Serial.println(F("microSD: Offline"));
+  }
+
+  //Release the semaphore
+  if (releaseSemaphore)
+    xSemaphoreGive(sdCardSemaphore);
+}
+
 //We want the UART2 interrupts to be pinned to core 0 to avoid competing with I2C interrupts
 //We do not start the UART2 for GNSS->BT reception here because the interrupts would be pinned to core 1
 //We instead start a task that runs on core 0, that then begins serial

--- a/Firmware/RTK_Surveyor/Buttons.ino
+++ b/Firmware/RTK_Surveyor/Buttons.ino
@@ -19,8 +19,8 @@ void powerOnCheck()
 //then don't display a shutdown screen
 void powerDown(bool displayInfo)
 {
-  //Disable logging
-  endLogging(false, false);
+  //Disable SD card use
+  endSD(false, false);
 
   //Prevent other tasks from logging, even if access to the microSD card was denied
   online.logging = false;

--- a/Firmware/RTK_Surveyor/Buttons.ino
+++ b/Firmware/RTK_Surveyor/Buttons.ino
@@ -19,24 +19,11 @@ void powerOnCheck()
 //then don't display a shutdown screen
 void powerDown(bool displayInfo)
 {
-  if (online.logging == true)
-  {
-    //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile()
-    //Wait up to 1000ms
-    if (xSemaphoreTake(sdCardSemaphore, 1000 / portTICK_PERIOD_MS) == pdPASS)
-    {
-      //Close down file system
-      ubxFile.sync();
-      ubxFile.close();
-      //xSemaphoreGive(sdCardSemaphore); //Do not release semaphore
-    } //End sdCardSemaphore
-    else
-    {
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
-    }
+  //Disable logging
+  endLogging(false, false);
 
-    online.logging = false;
-  }
+  //Prevent other tasks from logging, even if access to the microSD card was denied
+  online.logging = false;
 
   if (displayInfo == true)
   {

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -551,7 +551,7 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
   //Special actions
   else if (strcmp(settingName, "firmwareFileName") == 0)
   {
-    updateFromSD(settingValueStr);
+    mountSDThenUpdate(settingValueStr);
 
     //If update is successful, it will force system reset and not get here.
 

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -11,13 +11,13 @@ void startWebServer()
   if (online.microSD)
   {
     csd_t csd;
-    sd.card()->readCSD(&csd); //Card Specific Data
+    sd->card()->readCSD(&csd); //Card Specific Data
     sdCardSizeMB = 0.000512 * sdCardCapacity(&csd);
-    sd.volumeBegin();
+    sd->volumeBegin();
 
     //Find available cluster/space
-    sdFreeSpaceMB = sd.vol()->freeClusterCount(); //This takes a few seconds to complete
-    sdFreeSpaceMB *= sd.vol()->sectorsPerCluster() / 2;
+    sdFreeSpaceMB = sd->vol()->freeClusterCount(); //This takes a few seconds to complete
+    sdFreeSpaceMB *= sd->vol()->sectorsPerCluster() / 2;
     sdFreeSpaceMB /= 1024;
 
     sdUsedSpaceMB = sdCardSizeMB - sdFreeSpaceMB; //Don't think of it as used, think of it as unusable

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -74,8 +74,8 @@ void recordSystemSettingsToFileSD(char *fileName)
     if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
     {
       gotSemaphore = true;
-      if (sd.exists(fileName))
-        sd.remove(fileName);
+      if (sd->exists(fileName))
+        sd->remove(fileName);
 
       SdFile settingsFile; //FAT32
       if (settingsFile.open(fileName, O_CREAT | O_APPEND | O_WRITE) == false)
@@ -263,7 +263,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
     if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
     {
       gotSemaphore = true;
-      if (sd.exists(fileName))
+      if (sd->exists(fileName))
       {
         SdFile settingsFile; //FAT32
         if (settingsFile.open(fileName, O_READ) == false)

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -88,7 +88,9 @@ void recordSystemSettingsToFileSD(char *fileName)
     }
     else
     {
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      //This is an error because the current settings no longer match the settings
+      //on the microSD card, and will not be restored to the expected settings!
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
 }
@@ -294,7 +296,9 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
     } //End Semaphore check
     else
     {
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      //This is an error because if the settings exist on the microSD card that
+      //those settings are not overriding the current settings as documented!
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   } //End SD online
 

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -516,36 +516,12 @@ void updateLogs()
   else if (online.logging == true && settings.enableLogging == false)
   {
     //Close down file
-    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-    {
-      ubxFile.sync();
-      ubxFile.close();
-      online.logging = false;
-      xSemaphoreGive(sdCardSemaphore); //Release semaphore
-    }
-    else
-    {
-      //This is OK because in the interim more data will be written to the log
-      //and the log file will eventually be closed by the next call in loop
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
-    }
+    endLogging(false, true);
   }
   else if (online.logging == true && settings.enableLogging == true && (systemTime_minutes - startCurrentLogTime_minutes) >= settings.maxLogLength_minutes)
   {
     //Close down file. A new one will be created at the next calling of updateLogs().
-    if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-    {
-      ubxFile.sync();
-      ubxFile.close();
-      online.logging = false;
-      xSemaphoreGive(sdCardSemaphore); //Release semaphore
-    }
-    else
-    {
-      //This is OK because in the interim more data will be written to the log
-      //and the log file will eventually be closed by the next call in loop
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
-    }
+    endLogging(false, true);
   }
 
   if (online.logging == true)

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -103,7 +103,7 @@ ESP32Time rtc;
 #include <SPI.h>
 #include "SdFat.h" //http://librarymanager/All#sdfat_exfat by Bill Greiman. Currently uses v2.1.1
 
-SdFat sd;
+SdFat * sd;
 
 char platformFilePrefix[40] = "SFE_Surveyor"; //Sets the prefix for logs and settings files
 

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -525,6 +525,8 @@ void updateLogs()
     }
     else
     {
+      //This is OK because in the interim more data will be written to the log
+      //and the log file will eventually be closed by the next call in loop
       log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
@@ -540,6 +542,8 @@ void updateLogs()
     }
     else
     {
+      //This is OK because in the interim more data will be written to the log
+      //and the log file will eventually be closed by the next call in loop
       log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
@@ -569,6 +573,8 @@ void updateLogs()
       } //End sdCardSemaphore
       else
       {
+        //This is OK because in the interim more data will be written to the log
+        //and the log file will eventually be synced by the next call in loop
         log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
       }
     }
@@ -594,7 +600,10 @@ void updateLogs()
       }
       else
       {
-        log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+        //While a retry does occur during the next loop, it is possible to loose
+        //trigger events if they occur too rapidly or if the log file is closed
+        //before the trigger event is written!
+        log_w("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
       }
     }
 
@@ -612,6 +621,8 @@ void updateLogs()
       }
       else
       {
+      //This is OK because outputting this message is not critical to the RTK
+      //operation and the message will be output by the next call in loop
         log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
       }
 

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -107,7 +107,7 @@ SdFat sd;
 
 char platformFilePrefix[40] = "SFE_Surveyor"; //Sets the prefix for logs and settings files
 
-SdFile ubxFile; //File that all GNSS ubx messages sentences are written to
+SdFile * ubxFile; //File that all GNSS ubx messages sentences are written to
 unsigned long lastUBXLogSyncTime = 0; //Used to record to SD every half second
 int startLogTime_minutes = 0; //Mark when we start any logging so we can stop logging after maxLogTime_minutes
 int startCurrentLogTime_minutes = 0; //Mark when we start this specific log file so we can close it after x minutes and start a new one
@@ -533,14 +533,14 @@ void updateLogs()
           digitalWrite(pin_baseStatusLED, !digitalRead(pin_baseStatusLED)); //Blink LED to indicate logging activity
 
         long startWriteTime = micros();
-        ubxFile.sync();
+        ubxFile->sync();
         long stopWriteTime = micros();
         totalWriteTime += stopWriteTime - startWriteTime; //Used to calculate overall write speed
 
         if (productVariant == RTK_SURVEYOR)
           digitalWrite(pin_baseStatusLED, !digitalRead(pin_baseStatusLED)); //Return LED to previous state
 
-        updateDataFileAccess(&ubxFile); // Update the file access time & date
+        updateDataFileAccess(ubxFile); // Update the file access time & date
 
         lastUBXLogSyncTime = millis();
         xSemaphoreGive(sdCardSemaphore);
@@ -567,7 +567,7 @@ void updateLogs()
 
       if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
       {
-        ubxFile.println(nmeaMessage);
+        ubxFile->println(nmeaMessage);
 
         xSemaphoreGive(sdCardSemaphore);
         newEventToRecord = false;
@@ -589,7 +589,7 @@ void updateLogs()
       //Attempt to access file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
       if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
       {
-        fileSize = ubxFile.fileSize();
+        fileSize = ubxFile->fileSize();
 
         xSemaphoreGive(sdCardSemaphore);
       }

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -112,8 +112,6 @@ unsigned long lastUBXLogSyncTime = 0; //Used to record to SD every half second
 int startLogTime_minutes = 0; //Mark when we start any logging so we can stop logging after maxLogTime_minutes
 int startCurrentLogTime_minutes = 0; //Mark when we start this specific log file so we can close it after x minutes and start a new one
 
-SdFile newFirmwareFile; //File that is available if user uploads new firmware via web gui
-
 //System crashes if two tasks access a file at the same time
 //So we use a semaphore to see if file system is available
 SemaphoreHandle_t sdCardSemaphore;

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -516,12 +516,12 @@ void updateLogs()
   else if (online.logging == true && settings.enableLogging == false)
   {
     //Close down file
-    endLogging(false, true);
+    endSD(false, true);
   }
   else if (online.logging == true && settings.enableLogging == true && (systemTime_minutes - startCurrentLogTime_minutes) >= settings.maxLogLength_minutes)
   {
     //Close down file. A new one will be created at the next calling of updateLogs().
-    endLogging(false, true);
+    endSD(false, true);
   }
 
   if (online.logging == true)

--- a/Firmware/RTK_Surveyor/SD.ino
+++ b/Firmware/RTK_Surveyor/SD.ino
@@ -1,6 +1,6 @@
 /*
   These are low level functions to aid in detecting whether a card is present or not.
-  Because of ESP32 v2 core, SdFat can only operate using Shared SPI. This makes the sd.begin test take over 1s
+  Because of ESP32 v2 core, SdFat can only operate using Shared SPI. This makes the sd->begin test take over 1s
   which causes the RTK product to boot slowly. To circumvent this, we will ping the SD card directly to see if it responds.
   Failures take 2ms, successes take 1ms.
 

--- a/Firmware/RTK_Surveyor/States.ino
+++ b/Firmware/RTK_Surveyor/States.ino
@@ -784,7 +784,7 @@ void updateSystemState()
           {
             char nmeaMessage[82]; //Max NMEA sentence length is 82
             createNMEASentence(CUSTOM_NMEA_TYPE_WAYPOINT, nmeaMessage, (char*)"CustomEvent"); //textID, buffer, text
-            ubxFile.println(nmeaMessage);
+            ubxFile->println(nmeaMessage);
             displayEventMarked(500); //Show 'Event Marked'
           }
           else

--- a/Firmware/RTK_Surveyor/System.ino
+++ b/Firmware/RTK_Surveyor/System.ino
@@ -524,8 +524,8 @@ bool createTestFile()
 
   //File successfully created
   testFile.close();
-  if (sd.exists(testFileName))
-    sd.remove(testFileName);
+  if (sd->exists(testFileName))
+    sd->remove(testFileName);
   return (true);
 }
 

--- a/Firmware/RTK_Surveyor/System.ino
+++ b/Firmware/RTK_Surveyor/System.ino
@@ -518,33 +518,15 @@ bool createTestFile()
   SdFile testFile;
   char testFileName[40] = "testfile.txt";
 
-  if (sdCardSemaphore == NULL)
-  {
-    log_d("sdCardSemaphore is Null");
+  //Attempt to write to the file system
+  if (testFile.open(testFileName, O_CREAT | O_APPEND | O_WRITE) != true)
     return (false);
-  }
 
-  //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
-  if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
-  {
-    if (testFile.open(testFileName, O_CREAT | O_APPEND | O_WRITE) == true)
-    {
-      testFile.close();
-
-      if (sd.exists(testFileName))
-        sd.remove(testFileName);
-      xSemaphoreGive(sdCardSemaphore);
-      return (true);
-    }
-    xSemaphoreGive(sdCardSemaphore);
-  }
-  else
-  {
-    //This is OK because the next loop will retry bringing the microSD card online
-    log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
-  }
-
-  return (false);
+  //File successfully created
+  testFile.close();
+  if (sd.exists(testFileName))
+    sd.remove(testFileName);
+  return (true);
 }
 
 //If debug option is on, print available heap

--- a/Firmware/RTK_Surveyor/System.ino
+++ b/Firmware/RTK_Surveyor/System.ino
@@ -540,6 +540,7 @@ bool createTestFile()
   }
   else
   {
+    //This is OK because the next loop will retry bringing the microSD card online
     log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
   }
 

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -83,7 +83,8 @@ void F9PSerialReadTask(void *e)
           } //End sdCardSemaphore
           else
           {
-            log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+            //Error causing dropped bytes in the log file
+            Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
           }
         } //End maxLogTime
       } //End logging

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -77,7 +77,7 @@ void F9PSerialReadTask(void *e)
           //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile()
           if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_shortWait_ms) == pdPASS)
           {
-            ubxFile.write(rBuffer, s);
+            ubxFile->write(rBuffer, s);
 
             xSemaphoreGive(sdCardSemaphore);
           } //End sdCardSemaphore

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -135,7 +135,7 @@ void updateFromSD(const char *firmwareFileName)
   stopUART2Tasks();
 
   Serial.printf("Loading %s\n\r", firmwareFileName);
-  if (sd.exists(firmwareFileName))
+  if (sd->exists(firmwareFileName))
   {
     SdFile firmwareFile;
     firmwareFile.open(firmwareFileName, O_READ);
@@ -221,7 +221,7 @@ void updateFromSD(const char *firmwareFileName)
 
           //Remove forced firmware file to prevent endless loading
           firmwareFile.close();
-          sd.remove(firmwareFileName);
+          sd->remove(firmwareFileName);
 
           i2cGNSS.factoryReset(); //Reset everything: baud rate, I2C address, update rate, everything.
         }

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -96,7 +96,8 @@ void scanForFirmware()
     }
     else
     {
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      //This is an error when a firmware file is on the microSD card
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
 }

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -67,7 +67,7 @@ void mountSDThenUpdate(const char * firmwareFileName)
     } //End Semaphore check
     else
     {
-      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      Serial.printf("sdCardSemaphore failed to yield, menuFirmware.ino line %d\r\n", __LINE__);
     }
   }
 

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -183,8 +183,8 @@ void menuUserProfiles()
         //Remove profile from SD if available
         if (online.microSD == true)
         {
-          if (sd.exists(settingsFileName))
-            sd.remove(settingsFileName);
+          if (sd->exists(settingsFileName))
+            sd->remove(settingsFileName);
         }
 
         recordProfileNumber(0); //Move to Profile1
@@ -244,7 +244,7 @@ void factoryReset()
     if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
     {
       //Remove this specific settings file. Don't remove the other profiles.
-      sd.remove(settingsFileName);
+      sd->remove(settingsFileName);
       xSemaphoreGive(sdCardSemaphore);
     } //End sdCardSemaphore
     else

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -249,7 +249,10 @@ void factoryReset()
     } //End sdCardSemaphore
     else
     {
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      //An error occurs when a settings file is on the microSD card and it is not
+      //deleted, as such the settings on the microSD card will be loaded when the
+      //RTK reboots, resulting in failure to achieve the factory reset condition
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
 

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -344,13 +344,25 @@ void beginLogging()
                );
       }
 
+      //Allocate the ubxFile
+      if (!ubxFile)
+      {
+        ubxFile = new SdFile();
+        if (!ubxFile)
+        {
+          Serial.println(F("Failed to allocate ubxFile!"));
+          online.logging = false;
+          return;
+        }
+      }
+
       //Attempt to write to file system. This avoids collisions with file writing in F9PSerialReadTask()
       if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
       {
         // O_CREAT - create the file if it does not exist
         // O_APPEND - seek to the end of the file prior to each write
         // O_WRITE - open for write
-        if (ubxFile.open(fileName, O_CREAT | O_APPEND | O_WRITE) == false)
+        if (ubxFile->open(fileName, O_CREAT | O_APPEND | O_WRITE) == false)
         {
           Serial.printf("Failed to create GNSS UBX data file: %s\n\r", fileName);
           online.logging = false;
@@ -360,7 +372,7 @@ void beginLogging()
 
         lastLogSize = 0; //Reset counter - used for displaying active logging icon
 
-        updateDataFileCreate(&ubxFile); // Update the file to create time & date
+        updateDataFileCreate(ubxFile); // Update the file to create time & date
 
         startCurrentLogTime_minutes = millis() / 1000L / 60; //Mark now as start of logging
 
@@ -386,7 +398,7 @@ void beginLogging()
 
         char nmeaMessage[82]; //Max NMEA sentence length is 82
         createNMEASentence(CUSTOM_NMEA_TYPE_RESET_REASON, nmeaMessage, rstReason); //textID, buffer, text
-        ubxFile.println(nmeaMessage);
+        ubxFile->println(nmeaMessage);
 
         //Record system firmware versions and info to log
 
@@ -394,11 +406,11 @@ void beginLogging()
         char firmwareVersion[30]; //v1.3 December 31 2021
         sprintf(firmwareVersion, "v%d.%d-%s", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
         createNMEASentence(CUSTOM_NMEA_TYPE_SYSTEM_VERSION, nmeaMessage, firmwareVersion); //textID, buffer, text
-        ubxFile.println(nmeaMessage);
+        ubxFile->println(nmeaMessage);
 
         //ZED-F9P firmware: HPG 1.30
         createNMEASentence(CUSTOM_NMEA_TYPE_ZED_VERSION, nmeaMessage, zedFirmwareVersion); //textID, buffer, text
-        ubxFile.println(nmeaMessage);
+        ubxFile->println(nmeaMessage);
 
         if (reuseLastLog == true)
         {
@@ -431,10 +443,19 @@ void endLogging(bool gotSemaphore, bool releaseSemaphore)
     if (gotSemaphore
       || (xSemaphoreTake(sdCardSemaphore, 1000 / portTICK_PERIOD_MS) == pdPASS))
     {
-      //Close down file system
-      ubxFile.sync();
-      ubxFile.close();
+      if (sdPresent())
+      {
+        //Close down file system
+        ubxFile->sync();
+        ubxFile->close();
+        Serial.println(F("Log file closed"));
+      }
+      else
+        Serial.println(F("Log file - SD card not present, failed to close file"));
 
+      //Done with the log file
+      delete ubxFile;
+      ubxFile = NULL;
       online.logging = false;
 
       //Release the semaphore if requested

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -466,7 +466,7 @@ void endLogging(bool gotSemaphore, bool releaseSemaphore)
     {
       //This is OK because in the interim more data will be written to the log
       //and the log file will eventually be closed by the next call in loop
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      log_d("sdCardSemaphore failed to yield, menuMessages.ino line %d\r\n", __LINE__);
     }
   }
 }

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -422,7 +422,7 @@ void beginLogging()
       else
       {
         //A retry will happen during the next loop, the log will eventually be opened
-        log_d(F("Failed to get file system lock to create GNSS UBX data file"));
+        log_d("Failed to get file system lock to create GNSS UBX data file");
         online.logging = false;
         return;
       }

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -409,7 +409,8 @@ void beginLogging()
       }
       else
       {
-        Serial.println(F("Failed to get file system lock to create GNSS UBX data file"));
+        //A retry will happen during the next loop, the log will eventually be opened
+        log_d(F("Failed to get file system lock to create GNSS UBX data file"));
         online.logging = false;
         return;
       }
@@ -482,7 +483,9 @@ bool findLastLog(char *lastLogName)
     }
     else
     {
-      log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+      //Error when a log file exists on the microSD card, data should be appended
+      //to the existing log file
+      Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
     }
   }
 

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -145,7 +145,8 @@ void menuSystem()
       }
       else
       {
-        log_d("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+        //Error failed to list the contents of the microSD card
+        Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
       }
     }
     // Support mode switching

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -155,7 +155,7 @@ void menuSystem()
         else
         {
           //Error failed to list the contents of the microSD card
-          Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+          Serial.printf("sdCardSemaphore failed to yield, menuSystem.ino line %d\r\n", __LINE__);
         }
 
         //Release the SD card if not originally mounted

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -150,7 +150,7 @@ void menuSystem()
         if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
         {
           Serial.println(F("Files found (date time size name):\n\r"));
-          sd.ls(LS_R | LS_DATE | LS_SIZE);
+          sd->ls(LS_R | LS_DATE | LS_SIZE);
         }
         else
         {

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -1,6 +1,8 @@
 //Display current system status
 void menuSystem()
 {
+  bool sdCardAlreadyMounted;
+
   while (1)
   {
     Serial.println();
@@ -101,7 +103,7 @@ void menuSystem()
     }
     Serial.println();
 
-    if (settings.enableSD == true && online.microSD == true)
+    if (settings.enableSD == true)
     {
       Serial.println(F("f) Display microSD Files"));
     }
@@ -133,20 +135,34 @@ void menuSystem()
       else
         Serial.println(F("Reset aborted"));
     }
-    else if (incoming == 'f' && settings.enableSD == true && online.microSD == true)
+    else if ((incoming == 'f') && (settings.enableSD == true))
     {
-      //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
-      if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
-      {
-        Serial.println(F("Files found (date time size name):\n\r"));
-        sd.ls(LS_R | LS_DATE | LS_SIZE);
+      sdCardAlreadyMounted = online.microSD;
+      if (!online.microSD)
+        beginSD();
 
-        xSemaphoreGive(sdCardSemaphore);
-      }
+      //Notify the user if the microSD card is not available
+      if (!online.microSD)
+        Serial.println(F("microSD card not online!"));
       else
       {
-        //Error failed to list the contents of the microSD card
-        Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+        //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
+        if (xSemaphoreTake(sdCardSemaphore, fatSemaphore_longWait_ms) == pdPASS)
+        {
+          Serial.println(F("Files found (date time size name):\n\r"));
+          sd.ls(LS_R | LS_DATE | LS_SIZE);
+        }
+        else
+        {
+          //Error failed to list the contents of the microSD card
+          Serial.printf("sdCardSemaphore failed to yield, %s line %d\r\n", __FILE__, __LINE__);
+        }
+
+        //Release the SD card if not originally mounted
+        if (sdCardAlreadyMounted)
+          xSemaphoreGive(sdCardSemaphore);
+        else
+          endSD(true, true);
       }
     }
     // Support mode switching


### PR DESCRIPTION
With this change, I recommend only removing the microSD card when the RTK power is off or logging is not enabled.  Removing the microSD card when the RTK is powered on and logging is enabled is likely to corrupt the microSD card!

This change leaves the microSD card mounted anytime logging is enabled.  When logging is disabled the microSD card is dismounted.  All references to the microSD card are protected by the sdCardSemaphore.  References to the SD card while the system is active cause the SD card to be mounted first and then dismounted following the reference.  Listing the microSD card files from the Serial Config System menu, updating the firmware from the Serial Config Debug menu or via WiFi config are examples of this behavior.

The settings on the microSD card will override the current settings when the RTK system boots.  If the microSD card is inserted later, the settings are not loaded.

The following issues were fixed by this pull request:

1. The firmware update error when the wait for the sdCardSemaphore is eliminated by holding the semaphore during the entire beginSD routine.

2. The createTestFile routine is now called while holding the sdCardSemaphore eliminating the failure condition.

This pull request does not fix the following of the pre-existing errors.  The pull request does promote the error messages from log_d to Serial.printf:

1. The settings are not loaded from the microSD card when the code fails to obtain the sdCardSemaphore thus violating the documented settings priority!

2. The settings are not recorded on the microSD card when the code fails to obtain sdCardSemaphore.  This voilates the documented settings priority because the intended settings do not match the settings on the microSD card!

3. In menuSystem the code fails to list the SD card files upon failure to get the sdCardSemaphoore.

4. In findLastLog the code skips finding the last log file when failing to get the sdCardSemaphore. This leads to a new log file being created when data should be appended to an existing log file.

5. F9PSerialReadTask skips writing bytes to the log file, this is an error where a partial binary or NEMA message could be written to the log file.

6. In updateLogs the code skips writing trigger event to log file when failing to get the sdCardSemaphore.  While a retry occurs during the next loop, it is possible to loose trigger events if they occur too rapidly or if the log file is closed, changed log_d to log_w.

7. Log file data and trigger events may be lost when the log file is closed

The first two errors can be reduced  by increasing the wait time for the sdCardSemaphore, but the any failure violates the documented setting priority.

A better fix would be to eliminate the setting priority and keep the current settings in LittleFS.  A manual read and write from the microSD card using either Serial Config or the Setup Menu would save or restore the current settings.  No change would be necessary to the wait time for the sdCardSemaphore, but increasing the value may reduce the number of times a failure is seen.  While failures may occur, the user can easily retry the manual operation.

There is no solution for the third error.  It can be reduced by increasing the wait time for the sdCardSemaphore.  Note that the user can easily retry this manual operation when the error does occur.

There is no good solution for the fourth error, the wait is already set to 5 seconds.

For the fifth error, the wait time could be increased, but this might cause other issues in the serial data path.  Data is lost because the read is always starting at the beginning of the read buffer.  As a solution, increasing the size of the buffer and implementing ring buffer write algorithms for both Bluetooth and WiFi would enable several retry attempts before any data is lost due to congestion or failure to get the sdCardSemaphore.

The sixth error can be reduced by writing the data to the WiFi ring buffer described above.

The seventh error can be eliminated by flushing the WiFi ring buffer before the log file is closed.
