### PR TITLE
Update gis_software.md intro to Carlson SurvPC

### DIFF
--- a/docs/gis_software.md
+++ b/docs/gis_software.md
@@ -119,7 +119,7 @@ Now you can begin using the SparkFun RTK device with Field Genius.
 
 ## SurvPC
 
-Note: The company behind SurvPC, Carlson Software, is rather hostile to competitors of their $18,000 devices, so be warned.
+Note: The company behind SurvPC, Carlson Software, is not always welcoming to competitors of their $18,000 devices, so be warned.
 
 Be sure your device is [paired over Bluetooth](https://sparkfun.github.io/SparkFun_RTK_Firmware/connecting_bluetooth/#windows).
 


### PR DESCRIPTION
At the end of the SurvPC section, readers of the document are encouraged to contact Carlson Software and ask Carlson to incorporate support for SparkFun RTK into SurvPC.  If the long term goal is to have a working relationship with Carlson, let's not antagonize Carlson.  Therefore I suggest we remove the "hostile" language from the intro to SurvPC, however accurate it may be in describing someone's experiences.