### PR TITLE
Fix file dates by getting 24 hour instead of 12 hour time from the RTC

### DIFF
--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -477,8 +477,8 @@ void updateDataFileAccess(SdFile *dataFile)
   if (online.rtc == true)
   {
     //ESP32Time returns month:0-11
-    dataFile->timestamp(T_ACCESS, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(), rtc.getMinute(), rtc.getSecond());
-    dataFile->timestamp(T_WRITE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(), rtc.getMinute(), rtc.getSecond());
+    dataFile->timestamp(T_ACCESS, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(true), rtc.getMinute(), rtc.getSecond());
+    dataFile->timestamp(T_WRITE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(true), rtc.getMinute(), rtc.getSecond());
   }
 }
 
@@ -486,7 +486,7 @@ void updateDataFileAccess(SdFile *dataFile)
 void updateDataFileCreate(SdFile *dataFile)
 {
   if (online.rtc == true)
-    dataFile->timestamp(T_CREATE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(), rtc.getMinute(), rtc.getSecond()); //ESP32Time returns month:0-11
+    dataFile->timestamp(T_CREATE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(true), rtc.getMinute(), rtc.getSecond()); //ESP32Time returns month:0-11
 }
 
 //Finds last log


### PR DESCRIPTION
The GNSS is properly returning the UTC date and time which was used to
set the RTC.  The request to get the hours from the RTC was fetching the
0 - 11 value instead of the 0 - 23 value.  This change fetches the 0 -
23 value from the RTC for the hours.