### PR TITLE
Add Time zone support

### DIFF
--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -225,6 +225,9 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%d\n\r", F("updateZEDSettings"), settings.updateZEDSettings);
   settingsFile->printf("%s=%d\n\r", F("LBandFreq"), settings.LBandFreq);
   settingsFile->printf("%s=%d\n\r", F("enableLogging"), settings.enableLogging);
+  settingsFile->printf("%s=%d\n\r", F("timeZoneHours"), settings.timeZoneHours);
+  settingsFile->printf("%s=%d\n\r", F("timeZoneMinutes"), settings.timeZoneMinutes);
+  settingsFile->printf("%s=%d\n\r", F("timeZoneSeconds"), settings.timeZoneSeconds);
 
   //Record constellation settings
   for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
@@ -773,6 +776,12 @@ bool parseLine(char* str, Settings *settings)
   }
   else if (strcmp(settingName, "LBandFreq") == 0)
     settings->LBandFreq = d;
+  else if (strcmp(settingName, "timeZoneHours") == 0)
+    settings->timeZoneHours = d;
+  else if (strcmp(settingName, "timeZoneMinutes") == 0)
+    settings->timeZoneMinutes = d;
+  else if (strcmp(settingName, "timeZoneSeconds") == 0)
+    settings->timeZoneSeconds = d;
 
   //Check for bulk settings (constellations and message rates)
   //Must be last on else list

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -96,9 +96,6 @@ char settingsFileName[40]; //Contains the %s_Settings_%d.txt with current profil
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #include <ESP32Time.h> //http://librarymanager/All#ESP32Time
 ESP32Time rtc;
-int timeZoneHours;
-int timeZoneMinutes;
-int timeZoneSeconds;
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //microSD Interface
@@ -679,9 +676,9 @@ void updateRTC()
           second = i2cGNSS.getSecond(); //Range: 0 - 59
 
           //Perform time zone adjustment
-          second += timeZoneSeconds;
-          minute += timeZoneMinutes;
-          hour += timeZoneHours;
+          second += settings.timeZoneSeconds;
+          minute += settings.timeZoneMinutes;
+          hour += settings.timeZoneHours;
 
           //Set the internal system time
           //This is normally set with WiFi NTP but we will rarely have WiFi

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -643,20 +643,6 @@ void updateLogs()
   }
 }
 
-int getLeapDay(int month, int year)
-{
-  int leapDay;
-
-  //Determine if a leap day occurs in this month (February 29th exists)
-  //month range: 0 - 11
-  leapDay = ((month == (2 - 1))         //Leap day only occurs in February
-            && ((year & 3) == 0)        //Leap day occurs every 4 years
-            && (((year % 100) != 0)     //But not every 100 years
-              || ((year % 400) == 0)))  //But does occur every 400 years
-          ? 1 : 0;
-  return leapDay;
-}
-
 //Once we have a fix, sync system clock to GNSS
 //All SD writes will use the system date/time
 void updateRTC()
@@ -680,24 +666,6 @@ void updateRTC()
 
         if (timeValid == true)
         {
-          const int daysInMonth[] =
-          {
-            31, //January
-            28, //February
-            31, //March
-            30, //April
-            31, //May
-            30, //June
-            31, //July
-            31, //August
-            30, //September
-            31, //October
-            30, //November
-            31  //December
-          };
-          int year;
-          int month;
-          int day;
           int hour;
           int minute;
           int second;
@@ -706,89 +674,19 @@ void updateRTC()
           i2cGNSS.checkUblox();
 
           //Get the time values
-          year = i2cGNSS.getYear();
-          month = i2cGNSS.getMonth();   //Range: 1 - 12
-          day = i2cGNSS.getDay();       //Range: 1 - daysInMonth
           hour = i2cGNSS.getHour();     //Range: 0 - 23
           minute = i2cGNSS.getMinute(); //Range: 0 - 59
           second = i2cGNSS.getSecond(); //Range: 0 - 59
 
-          //Adjust month and day ranges
-          month -= 1;   //New range: 0 - 11
-          day -= 1;     //New range: 0 - (daysInMonth - 1)
-
-          //Perform time zone seconds adjustment
+          //Perform time zone adjustment
           second += timeZoneSeconds;
-          while (second < 0)
-          {
-            second += 60;
-            minute -= 1;
-          }
-
-          //Perform time zone minutes adjustment
           minute += timeZoneMinutes;
-          while (minute < 0)
-          {
-            minute += 60;
-            hour -= 1;
-          }
-
-          //Perform time zone hours adjustment
           hour += timeZoneHours;
-          while (hour < 0)
-          {
-            hour += 24;
-            day -= 1;
-
-            //Handle the day ripple
-            if (day < 0)
-            {
-              month -= 1;
-
-              //Handle the month ripple
-              if (month < 0)
-              {
-                month = 11;
-                year -= 1;
-              }
-              day = daysInMonth[month] + getLeapDay(month, year) - 1;
-            }
-          }
-
-          //hour needs to be in the range of 0 - 23
-          //Determine if the time is in the next day
-          while (hour >= 24)
-          {
-            //Adjust the hour and day
-            hour -= 24;
-            day += 1;
-
-            //day needs to be within the range of 0 - (daysInMonth - 1)
-            //Determine if the time is in the next month
-            if (day >= (daysInMonth[month] + getLeapDay(month, year)))
-            {
-              //Adjust day and month
-              day = 0;
-              month += 1;
-              //month needs to be within the range of 0 - 11
-              //Determine if the time is in the next year
-              if (month >= 12)
-              {
-                //Adjust the month and year
-                month = 0;
-                year += 1;
-              }
-            }
-          }
-
-          //Adjust month and day ranges
-          month += 1;   //New range: 1 - 12
-          day += 1;     //New range: 1 - daysInMonth
 
           //Set the internal system time
           //This is normally set with WiFi NTP but we will rarely have WiFi
           //rtc.setTime(gnssSecond, gnssMinute, gnssHour, gnssDay, gnssMonth, gnssYear);
-          rtc.setTime(second, minute, hour, day, month, year);
+          rtc.setTime(second, minute, hour, i2cGNSS.getDay(), i2cGNSS.getMonth(), i2cGNSS.getYear());
 
           online.rtc = true;
 

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -477,8 +477,8 @@ void updateDataFileAccess(SdFile *dataFile)
   if (online.rtc == true)
   {
     //ESP32Time returns month:0-11
-    dataFile->timestamp(T_ACCESS, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(), rtc.getMinute(), rtc.getSecond());
-    dataFile->timestamp(T_WRITE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(), rtc.getMinute(), rtc.getSecond());
+    dataFile->timestamp(T_ACCESS, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(true), rtc.getMinute(), rtc.getSecond());
+    dataFile->timestamp(T_WRITE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(true), rtc.getMinute(), rtc.getSecond());
   }
 }
 
@@ -486,7 +486,7 @@ void updateDataFileAccess(SdFile *dataFile)
 void updateDataFileCreate(SdFile *dataFile)
 {
   if (online.rtc == true)
-    dataFile->timestamp(T_CREATE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(), rtc.getMinute(), rtc.getSecond()); //ESP32Time returns month:0-11
+    dataFile->timestamp(T_CREATE, rtc.getYear(), rtc.getMonth() + 1, rtc.getDay(), rtc.getHour(true), rtc.getMinute(), rtc.getSecond()); //ESP32Time returns month:0-11
 }
 
 //Finds last log

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -109,6 +109,9 @@ void menuSystem()
     }
 
     Serial.println(F("d) Configure Debug"));
+    Serial.printf("h) Set time zone hours: %d\r\n", timeZoneHours);
+    Serial.printf("m) Set time zone minutes: %d\r\n", timeZoneMinutes);
+    Serial.printf("s) Set time zone seconds: %d\r\n", timeZoneSeconds);
 
     Serial.println(F("r) Reset all settings to default"));
 
@@ -124,6 +127,45 @@ void menuSystem()
 
     if (incoming == 'd')
       menuDebug();
+    else if (incoming == 'h')
+    {
+      Serial.print(F("Enter time zone hour offset (-23 <= offset <= 23): "));
+      int64_t value = getNumber(menuTimeout);
+      if (value < -23 || value > 23)
+        Serial.println(F("Error: -24 < hours < 24"));
+      else
+      {
+        timeZoneHours = value;
+        online.rtc = false;
+        updateRTC();
+      }
+    }
+    else if (incoming == 'm')
+    {
+      Serial.print(F("Enter time zone minute offset (-59 <= offset <= 59): "));
+      int64_t value = getNumber(menuTimeout);
+      if (value < -59 || value > 59)
+        Serial.println(F("Error: -60 < minutes < 60"));
+      else
+      {
+        timeZoneMinutes = value;
+        online.rtc = false;
+        updateRTC();
+      }
+    }
+    else if (incoming == 's')
+    {
+      Serial.print(F("Enter time zone second offset (-59 <= offset <= 59): "));
+      int64_t value = getNumber(menuTimeout);
+      if (value < -59 || value > 59)
+        Serial.println(F("Error: -60 < seconds < 60"));
+      else
+      {
+        timeZoneSeconds = value;
+        online.rtc = false;
+        updateRTC();
+      }
+    }
     else if (incoming == 'r')
     {
       Serial.println(F("\r\nResetting to factory defaults. Press 'y' to confirm:"));

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -109,9 +109,9 @@ void menuSystem()
     }
 
     Serial.println(F("d) Configure Debug"));
-    Serial.printf("h) Set time zone hours: %d\r\n", timeZoneHours);
-    Serial.printf("m) Set time zone minutes: %d\r\n", timeZoneMinutes);
-    Serial.printf("s) Set time zone seconds: %d\r\n", timeZoneSeconds);
+    Serial.printf("h) Set time zone hours: %d\r\n", settings.timeZoneHours);
+    Serial.printf("m) Set time zone minutes: %d\r\n", settings.timeZoneMinutes);
+    Serial.printf("s) Set time zone seconds: %d\r\n", settings.timeZoneSeconds);
 
     Serial.println(F("r) Reset all settings to default"));
 
@@ -135,7 +135,7 @@ void menuSystem()
         Serial.println(F("Error: -24 < hours < 24"));
       else
       {
-        timeZoneHours = value;
+        settings.timeZoneHours = value;
         online.rtc = false;
         updateRTC();
       }
@@ -148,7 +148,7 @@ void menuSystem()
         Serial.println(F("Error: -60 < minutes < 60"));
       else
       {
-        timeZoneMinutes = value;
+        settings.timeZoneMinutes = value;
         online.rtc = false;
         updateRTC();
       }
@@ -161,7 +161,7 @@ void menuSystem()
         Serial.println(F("Error: -60 < seconds < 60"));
       else
       {
-        timeZoneSeconds = value;
+        settings.timeZoneSeconds = value;
         online.rtc = false;
         updateRTC();
       }

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -392,6 +392,11 @@ typedef struct {
   uint64_t lastKeyAttempt = 0; //Epoch time of last attempt at obtaining keys
   bool updateZEDSettings = true; //When in doubt, update the ZED with current settings
   uint32_t LBandFreq = 1556290000; //Default to US band
+
+  //Time Zone - Default to UTC
+  int8_t timeZoneHours = 0;
+  int8_t timeZoneMinutes = 0;
+  int8_t timeZoneSeconds = 0;
 } Settings;
 Settings settings;
 


### PR DESCRIPTION
Add the ability to set the time zone (hours, minutes and seconds) to the system menu.  The default for these values is zero.  Adjust the real time clock (RTC) based upon the time zone offset.  The RTC clock value is used for the file time stamps.