### PR TITLE
WiFi Config: Display button down arrows after save

### DIFF
--- a/Firmware/RTK_Surveyor/AP-Config/index.html
+++ b/Firmware/RTK_Surveyor/AP-Config/index.html
@@ -97,7 +97,7 @@
             <div class="d-grid gap-2">
                 <button class="btn btn-primary toggle-btn" type="button" data-toggle="collapse"
                     data-target="#collapseGNSSConfig" aria-expanded="false" aria-controls="collapseGNSSConfig">
-                    GNSS Configuration <i class="caret-icon bi icon-caret-up"></i>
+                    GNSS Configuration <i id="gnssCaret" class="caret-icon bi icon-caret-up"></i>
                 </button>
             </div>
             <div class="collapse show" id="collapseGNSSConfig">
@@ -265,8 +265,8 @@
                                 <input type="text" class="form-control" id="ntripClient_MountPointPW">
                                 <p id="ntripClient_MountPointPWError" class="inlineError"></p>
                             </div>
-                        </div>                    
-                        
+                        </div>
+
                         <div class="form-check mt-1 box-margin20">
                             <label class="form-check-label" for="ntripClient_TransmitGGA">Transmit GGA to Caster</label>
                             <input class="form-check-input" type="checkbox" value="" id="ntripClient_TransmitGGA" unchecked>
@@ -276,12 +276,12 @@
                             </span>
                         </div>
                     </div>
-                    
+
                     <div id="messageRateButton">
                         <button class="btn btn-md btn-outline-primary mt-3 toggle-btn" type="button"
                             data-toggle="collapse" data-target="#collapseGNSSConfigMsg" aria-expanded="false"
                             aria-controls="collapseGNSSConfigMsg">
-                            Message Rates <i class="caret-icon bi icon-caret-down"></i>
+                            Message Rates <i id="gnssMsgCaret" class="caret-icon bi icon-caret-down"></i>
                         </button>
                         <span class="tt" data-bs-placement="right"
                             title="NMEA and RAWX are the two most commonly reported types of message but the receiver supports more than 70 different messages. Each message rate input controls which messages are disabled (0) and how often the message is reported (1 = one message reported per 1 fix, 5 = one report every 5 fixes). Default: NMEA GGA, GSA, GST, GSV, and RMC. Limits: 0 to 20.">
@@ -846,7 +846,7 @@
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" id="baseConfig" type="button" data-toggle="collapse"
                     data-target="#collapseBaseConfig" aria-expanded="false" aria-controls="collapseBaseConfig">
-                    Base Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    Base Configuration <i id="baseCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapseBaseConfig">
@@ -1055,7 +1055,7 @@
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" id="sensorConfig" type="button" data-toggle="collapse"
                     data-target="#collapseSensorConfig" aria-expanded="false" aria-controls="collapseSensorConfig">
-                    Sensor Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    Sensor Configuration <i id="sensorCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapseSensorConfig">
@@ -1083,7 +1083,7 @@
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" id="ppConfig" type="button" data-toggle="collapse"
                     data-target="#collapsePPConfig" aria-expanded="false" aria-controls="collapsePPConfig">
-                    PointPerfect Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    PointPerfect Configuration <i id="pointPerfectCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapsePPConfig">
@@ -1149,12 +1149,12 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- --------- Ports Config --------- -->
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
                     data-target="#collapsePortsConfig" aria-expanded="false" aria-controls="collapsePortsConfig">
-                    Ports Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    Ports Configuration <i id="portsCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapsePortsConfig">
@@ -1270,7 +1270,7 @@
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
                     data-target="#collapseSystemConfig" aria-expanded="false" aria-controls="collapseSystemConfig">
-                    System Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    System Configuration <i id="systemCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapseSystemConfig">

--- a/Firmware/RTK_Surveyor/AP-Config/src/main.js
+++ b/Firmware/RTK_Surveyor/AP-Config/src/main.js
@@ -186,15 +186,22 @@ function checkMessageValue(id) {
     checkElementValue(id, 0, 20, "Must be between 0 and 20", "collapseGNSSConfigMsg");
 }
 
+function collapseSection(section, caret) {
+    ge(section).classList.remove('show');
+    ge(caret).classList.remove('icon-caret-down');
+    ge(caret).classList.remove('icon-caret-up');
+    ge(caret).classList.add('icon-caret-down');
+}
+
 function validateFields() {
     //Collapse all sections
-    ge("collapseGNSSConfig").classList.remove('show');
-    ge("collapseGNSSConfigMsg").classList.remove('show');
-    ge("collapseBaseConfig").classList.remove('show');
-    ge("collapseSensorConfig").classList.remove('show');
-    ge("collapsePPConfig").classList.remove('show');
-    ge("collapsePortsConfig").classList.remove('show');
-    ge("collapseSystemConfig").classList.remove('show');
+    collapseSection("collapseGNSSConfig", "gnssCaret");
+    collapseSection("collapseGNSSConfigMsg", "gnssMsgCaret");
+    collapseSection("collapseBaseConfig", "baseCaret");
+    collapseSection("collapseSensorConfig", "sensorCaret");
+    collapseSection("collapsePPConfig", "pointPerfectCaret");
+    collapseSection("collapsePortsConfig", "portsCaret");
+    collapseSection("collapseSystemConfig", "systemCaret");
 
     errorCount = 0;
 
@@ -378,7 +385,7 @@ function validateFields() {
         if(ge("enablePointPerfectCorrections").checked == true) {
             checkElementString("home_wifiSSID", 1, 30, "Must be 1 to 30 characters", "collapsePPConfig");
             checkElementString("home_wifiPW", 0, 30, "Must be 0 to 30 characters", "collapsePPConfig");
-            
+
             value = ge("pointPerfectDeviceProfileToken").value;
             console.log(value);
             if (value.length > 0)

--- a/Firmware/RTK_Surveyor/form.h
+++ b/Firmware/RTK_Surveyor/form.h
@@ -209,15 +209,22 @@ function checkMessageValue(id) {
     checkElementValue(id, 0, 20, "Must be between 0 and 20", "collapseGNSSConfigMsg");
 }
 
+function collapseSection(section, caret) {
+    ge(section).classList.remove('show');
+    ge(caret).classList.remove('icon-caret-down');
+    ge(caret).classList.remove('icon-caret-up');
+    ge(caret).classList.add('icon-caret-down');
+}
+
 function validateFields() {
     //Collapse all sections
-    ge("collapseGNSSConfig").classList.remove('show');
-    ge("collapseGNSSConfigMsg").classList.remove('show');
-    ge("collapseBaseConfig").classList.remove('show');
-    ge("collapseSensorConfig").classList.remove('show');
-    ge("collapsePPConfig").classList.remove('show');
-    ge("collapsePortsConfig").classList.remove('show');
-    ge("collapseSystemConfig").classList.remove('show');
+    collapseSection("collapseGNSSConfig", "gnssCaret");
+    collapseSection("collapseGNSSConfigMsg", "gnssMsgCaret");
+    collapseSection("collapseBaseConfig", "baseCaret");
+    collapseSection("collapseSensorConfig", "sensorCaret");
+    collapseSection("collapsePPConfig", "pointPerfectCaret");
+    collapseSection("collapsePortsConfig", "portsCaret");
+    collapseSection("collapseSystemConfig", "systemCaret");
 
     errorCount = 0;
 
@@ -401,7 +408,7 @@ function validateFields() {
         if(ge("enablePointPerfectCorrections").checked == true) {
             checkElementString("home_wifiSSID", 1, 30, "Must be 1 to 30 characters", "collapsePPConfig");
             checkElementString("home_wifiPW", 0, 30, "Must be 0 to 30 characters", "collapsePPConfig");
-            
+
             value = ge("pointPerfectDeviceProfileToken").value;
             console.log(value);
             if (value.length > 0)
@@ -863,7 +870,7 @@ static const char *index_html = R"=====(
             <div class="d-grid gap-2">
                 <button class="btn btn-primary toggle-btn" type="button" data-toggle="collapse"
                     data-target="#collapseGNSSConfig" aria-expanded="false" aria-controls="collapseGNSSConfig">
-                    GNSS Configuration <i class="caret-icon bi icon-caret-up"></i>
+                    GNSS Configuration <i id="gnssCaret" class="caret-icon bi icon-caret-up"></i>
                 </button>
             </div>
             <div class="collapse show" id="collapseGNSSConfig">
@@ -1031,8 +1038,8 @@ static const char *index_html = R"=====(
                                 <input type="text" class="form-control" id="ntripClient_MountPointPW">
                                 <p id="ntripClient_MountPointPWError" class="inlineError"></p>
                             </div>
-                        </div>                    
-                        
+                        </div>
+
                         <div class="form-check mt-1 box-margin20">
                             <label class="form-check-label" for="ntripClient_TransmitGGA">Transmit GGA to Caster</label>
                             <input class="form-check-input" type="checkbox" value="" id="ntripClient_TransmitGGA" unchecked>
@@ -1042,12 +1049,12 @@ static const char *index_html = R"=====(
                             </span>
                         </div>
                     </div>
-                    
+
                     <div id="messageRateButton">
                         <button class="btn btn-md btn-outline-primary mt-3 toggle-btn" type="button"
                             data-toggle="collapse" data-target="#collapseGNSSConfigMsg" aria-expanded="false"
                             aria-controls="collapseGNSSConfigMsg">
-                            Message Rates <i class="caret-icon bi icon-caret-down"></i>
+                            Message Rates <i id="gnssMsgCaret" class="caret-icon bi icon-caret-down"></i>
                         </button>
                         <span class="tt" data-bs-placement="right"
                             title="NMEA and RAWX are the two most commonly reported types of message but the receiver supports more than 70 different messages. Each message rate input controls which messages are disabled (0) and how often the message is reported (1 = one message reported per 1 fix, 5 = one report every 5 fixes). Default: NMEA GGA, GSA, GST, GSV, and RMC. Limits: 0 to 20.">
@@ -1612,7 +1619,7 @@ static const char *index_html = R"=====(
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" id="baseConfig" type="button" data-toggle="collapse"
                     data-target="#collapseBaseConfig" aria-expanded="false" aria-controls="collapseBaseConfig">
-                    Base Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    Base Configuration <i id="baseCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapseBaseConfig">
@@ -1821,7 +1828,7 @@ static const char *index_html = R"=====(
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" id="sensorConfig" type="button" data-toggle="collapse"
                     data-target="#collapseSensorConfig" aria-expanded="false" aria-controls="collapseSensorConfig">
-                    Sensor Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    Sensor Configuration <i id="sensorCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapseSensorConfig">
@@ -1849,7 +1856,7 @@ static const char *index_html = R"=====(
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" id="ppConfig" type="button" data-toggle="collapse"
                     data-target="#collapsePPConfig" aria-expanded="false" aria-controls="collapsePPConfig">
-                    PointPerfect Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    PointPerfect Configuration <i id="pointPerfectCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapsePPConfig">
@@ -1870,7 +1877,6 @@ static const char *index_html = R"=====(
                     </div>
 
                     <div id="ppSettingsConfig">
-
                         <div class="form-group row">
                             <label for="home_wifiSSID" class="box-margin20 col-sm-3 col-4 col-form-label">Home WiFi
                                 SSID:</label>
@@ -1916,12 +1922,12 @@ static const char *index_html = R"=====(
                     </div>
                 </div>
             </div>
-            
+
             <!-- --------- Ports Config --------- -->
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
                     data-target="#collapsePortsConfig" aria-expanded="false" aria-controls="collapsePortsConfig">
-                    Ports Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    Ports Configuration <i id="portsCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapsePortsConfig">
@@ -2037,7 +2043,7 @@ static const char *index_html = R"=====(
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
                     data-target="#collapseSystemConfig" aria-expanded="false" aria-controls="collapseSystemConfig">
-                    System Configuration <i class="caret-icon bi icon-caret-down"></i>
+                    System Configuration <i id="systemCaret" class="caret-icon bi icon-caret-down"></i>
                 </button>
             </div>
             <div class="collapse" id="collapseSystemConfig">


### PR DESCRIPTION
There was a display bug when a section (e.g GNSS Config) was opened up
and the save button is pressed.  Prior to pressing the save button, the
arrow on the section button (e.g. GNSS Config) is point up to indicate
that the section may be collapsed.  After pressing the save button, the
section is collapsed but the arrow on the section button remains
pointing up.

This change fixes this display error by changing all of the section
buttons to have a down arrow.  Each of the caret icons is given a name
(id) and any icon direction is removed and the icon down direction is
added.