### PR TITLE
Set active profile bit when profile name is changed

### DIFF
--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -488,7 +488,7 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
   else if (strcmp(settingName, "profileName") == 0)
   {
     strcpy(settings.profileName, settingValueStr);
-    strcpy(profileNames[profileNumber], settingValueStr);
+    setProfileName(profileNumber);
   }
   else if (strcmp(settingName, "profileNumber") == 0)
   {

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -975,6 +975,16 @@ Serial.printf("profiles: 0x%02x\r\n", profiles);
   return (profiles);
 }
 
+//Copy the profile name into the array of profile names
+void setProfileName(uint8_t ProfileNumber)
+{
+  //Update the name in the array of profile names
+  strcpy(profileNames[profileNumber], settings.profileName);
+
+  //Mark this profile as active
+  activeProfiles |= 1 << ProfileNumber;
+}
+
 //Open the clear text file, scan for 'profileName' and return the string
 //Returns true if successfully found tag in file, length may be zero
 //Looks at LittleFS first, then SD

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -156,8 +156,7 @@ void menuUserProfiles()
 
       recordProfileNumber(incoming - 1); //Align to array
       profileNumber = incoming - 1;
-
-      sprintf(settingsFileName, "/%s_Settings_%d.txt", platformFilePrefix, profileNumber); //Enables Delete Profile
+      setSettingsFileName(); //Enables Delete Profile
 
       //We need to load these settings from file so that we can record a profile name change correctly
       bool responseLFS = loadSystemSettingsFromFileLFS(settingsFileName, &settings);
@@ -175,8 +174,7 @@ void menuUserProfiles()
       Serial.print("Enter new profile name: ");
       readLine(settings.profileName, sizeof(settings.profileName), menuTimeoutExtended);
       recordSystemSettings(); //We need to update this immediately in case user lists the available profiles again
-
-      strcpy(profileNames[profileNumber], settings.profileName); //Update array
+      setProfileName(profileNumber);
     }
     else if (incoming == MAX_PROFILE_COUNT + 2)
     {


### PR DESCRIPTION
Add setProfileName routine to copy the profile name from settings into
the profile name array.  This routine also sets the activeProfile bit.

Use setProfileName in Form.ino and menuMain.ino.

Use setSettingsFileName in menuMain.ino, already in use by Form.ino.