### PR TITLE
Display the profile names and select the boot profile using WiFi Config

### DIFF
--- a/Firmware/RTK_Surveyor/AP-Config/index.html
+++ b/Firmware/RTK_Surveyor/AP-Config/index.html
@@ -119,7 +119,7 @@
                     </div>
 
                     <div class="form-group row mt-2">
-                        <span id="profileList" style="display:inline; margin-left:20px;"><Strong>Profiles</strong></span>
+                        <span id="activeProfiles" style="display:inline; margin-left:20px;"><Strong>Profiles</strong></span>
                     </div>
                     <div class="form-group row">
                         <span id="profile0Name" style="display:inline; margin-left:40px;">1: 12345678901234567890123456789012345678901234567890</span>

--- a/Firmware/RTK_Surveyor/AP-Config/index.html
+++ b/Firmware/RTK_Surveyor/AP-Config/index.html
@@ -117,6 +117,42 @@
                             <p id="profileNameError" class="inlineError"></p>
                         </div>
                     </div>
+
+                    <div class="form-group row mt-2">
+                        <span id="profileList" style="display:inline; margin-left:20px;"><Strong>Profiles</strong></span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile0Name" style="display:inline; margin-left:40px;">1: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile1Name" style="display:inline; margin-left:40px;">2: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile2Name" style="display:inline; margin-left:40px;">3: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile3Name" style="display:inline; margin-left:40px;">4: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile4Name" style="display:inline; margin-left:40px;">5: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile5Name" style="display:inline; margin-left:40px;">6: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile6Name" style="display:inline; margin-left:40px;">7: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row mb-3">
+                        <span id="profile7Name" style="display:inline; margin-left:40px;">8: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="bootProfileName" class="box-margin20 col-sm-3 col-4 col-form-label">Boot Profile</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="bootProfileNumber">
+                            <p id="bootProfileNumberError" class="inlineError"></p>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/Firmware/RTK_Surveyor/AP-Config/src/main.js
+++ b/Firmware/RTK_Surveyor/AP-Config/src/main.js
@@ -208,7 +208,7 @@ function validateFields() {
     errorCount = 0;
 
     //Profile Config
-    checkElementValue("profileNumber", 1, 4, "Must be between 1 and 4", "collapseProfileConfig");
+    checkElementValue("profileNumber", 1, 8, "Must be between 1 and 8", "collapseProfileConfig");
     checkElementString("profileName", 1, 49, "Must be 1 to 49 characters", "collapseProfileConfig");
 
     //GNSS Config

--- a/Firmware/RTK_Surveyor/AP-Config/src/main.js
+++ b/Firmware/RTK_Surveyor/AP-Config/src/main.js
@@ -132,6 +132,7 @@ function parseIncoming(msg) {
     //Force element updates
     ge("profileNumber").dispatchEvent(new CustomEvent('change'));
     ge("profileName").dispatchEvent(new CustomEvent('change'));
+    ge("bootProfileNumber").dispatchEvent(new CustomEvent('change'));
     ge("measurementRateHz").dispatchEvent(new CustomEvent('change'));
     ge("baseTypeSurveyIn").dispatchEvent(new CustomEvent('change'));
     ge("baseTypeFixed").dispatchEvent(new CustomEvent('change'));
@@ -218,6 +219,7 @@ function validateFields() {
     //Profile Config
     checkElementValue("profileNumber", 1, 8, "Must be between 1 and 8", "collapseProfileConfig");
     checkElementString("profileName", 1, 49, "Must be 1 to 49 characters", "collapseProfileConfig");
+    checkBitMapValue("bootProfileNumber", 1, 8, "activeProfiles", "Must be an active profile between 1 and 8", "collapseProfileConfig");
 
     //GNSS Config
     checkElementValue("measurementRateHz", 0.00012, 10, "Must be between 0.00012 and 10Hz", "collapseGNSSConfig");
@@ -465,6 +467,19 @@ function checkConstellations() {
     }
     else
         clearError("ubxConstellations");
+}
+
+function checkBitMapValue(id, min, max, bitMap, errorText, collapseID) {
+    value = ge(id).value;
+    mask = ge(bitMap).value;
+    if ((value < min) || (value > max) || ((mask & (1 << value)) == 0)) {
+        ge(id + 'Error').innerHTML = 'Error: ' + errorText;
+        ge(collapseID).classList.add('show');
+        errorCount++;
+    }
+    else {
+        clearError(id);
+    }
 }
 
 function checkElementValue(id, min, max, errorText, collapseID) {

--- a/Firmware/RTK_Surveyor/AP-Config/src/main.js
+++ b/Firmware/RTK_Surveyor/AP-Config/src/main.js
@@ -84,6 +84,14 @@ function parseIncoming(msg) {
             || id.includes("zedFirmwareVersion")
             || id.includes("hardwareID")
             || id.includes("daysRemaining")
+            || id.includes("profile0Name")
+            || id.includes("profile1Name")
+            || id.includes("profile2Name")
+            || id.includes("profile3Name")
+            || id.includes("profile4Name")
+            || id.includes("profile5Name")
+            || id.includes("profile6Name")
+            || id.includes("profile7Name")
         ) {
             ge(id).innerHTML = val;
         }

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -600,6 +600,12 @@ Serial.printf("bootProfileNumber: %d\r\n", bootProfileNumber);
   {
     if (newAPSettings == true) recordSystemSettings(); //If we've recieved settings, record before restart
 
+    //Determine which profile to boot
+    bootProfileNumber -= 1;
+    if (bootProfileNumber != profileNumber)
+      recordProfileNumber(bootProfileNumber);
+
+    //Reboot the machine
     ESP.restart();
   }
 

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -523,6 +523,7 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
       || (bootProfileNumber < 1)
       || (bootProfileNumber > (MAX_PROFILE_COUNT + 1)))
       bootProfileNumber = 1;
+Serial.printf("bootProfileNumber: %d\r\n", bootProfileNumber);
   }
   else if (strcmp(settingName, "enableNtripServer") == 0)
     settings.enableNtripServer = settingValueBool;

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -305,7 +305,7 @@ AsyncWebSocket ws("/ws");
 
 //Because the incoming string is longer than max len, there are multiple callbacks so we
 //use a global to combine the incoming
-#define AP_CONFIG_SETTING_SIZE 3500
+#define AP_CONFIG_SETTING_SIZE 5000
 char incomingSettings[AP_CONFIG_SETTING_SIZE];
 int incomingSettingsSpot = 0;
 unsigned long timeSinceLastIncomingSetting = 0;

--- a/Firmware/RTK_Surveyor/form.h
+++ b/Firmware/RTK_Surveyor/form.h
@@ -107,6 +107,14 @@ function parseIncoming(msg) {
             || id.includes("zedFirmwareVersion")
             || id.includes("hardwareID")
             || id.includes("daysRemaining")
+            || id.includes("profile0Name")
+            || id.includes("profile1Name")
+            || id.includes("profile2Name")
+            || id.includes("profile3Name")
+            || id.includes("profile4Name")
+            || id.includes("profile5Name")
+            || id.includes("profile6Name")
+            || id.includes("profile7Name")
         ) {
             ge(id).innerHTML = val;
         }

--- a/Firmware/RTK_Surveyor/form.h
+++ b/Firmware/RTK_Surveyor/form.h
@@ -155,6 +155,7 @@ function parseIncoming(msg) {
     //Force element updates
     ge("profileNumber").dispatchEvent(new CustomEvent('change'));
     ge("profileName").dispatchEvent(new CustomEvent('change'));
+    ge("bootProfileNumber").dispatchEvent(new CustomEvent('change'));
     ge("measurementRateHz").dispatchEvent(new CustomEvent('change'));
     ge("baseTypeSurveyIn").dispatchEvent(new CustomEvent('change'));
     ge("baseTypeFixed").dispatchEvent(new CustomEvent('change'));
@@ -241,6 +242,7 @@ function validateFields() {
     //Profile Config
     checkElementValue("profileNumber", 1, 8, "Must be between 1 and 8", "collapseProfileConfig");
     checkElementString("profileName", 1, 49, "Must be 1 to 49 characters", "collapseProfileConfig");
+    checkBitMapValue("bootProfileNumber", 1, 8, "activeProfiles", "Must be an active profile between 1 and 8", "collapseProfileConfig");
 
     //GNSS Config
     checkElementValue("measurementRateHz", 0.00012, 10, "Must be between 0.00012 and 10Hz", "collapseGNSSConfig");
@@ -488,6 +490,19 @@ function checkConstellations() {
     }
     else
         clearError("ubxConstellations");
+}
+
+function checkBitMapValue(id, min, max, bitMap, errorText, collapseID) {
+    value = ge(id).value;
+    mask = ge(bitMap).value;
+    if ((value < min) || (value > max) || ((mask & (1 << value)) == 0)) {
+        ge(id + 'Error').innerHTML = 'Error: ' + errorText;
+        ge(collapseID).classList.add('show');
+        errorCount++;
+    }
+    else {
+        clearError(id);
+    }
 }
 
 function checkElementValue(id, min, max, errorText, collapseID) {
@@ -906,7 +921,7 @@ static const char *index_html = R"=====(
                     </div>
 
                     <div class="form-group row mt-2">
-                        <span id="profileList" style="display:inline; margin-left:20px;"><Strong>Profiles</strong></span>
+                        <span id="activeProfiles" style="display:inline; margin-left:20px;"><Strong>Profiles</strong></span>
                     </div>
                     <div class="form-group row">
                         <span id="profile0Name" style="display:inline; margin-left:40px;">1: 12345678901234567890123456789012345678901234567890</span>

--- a/Firmware/RTK_Surveyor/form.h
+++ b/Firmware/RTK_Surveyor/form.h
@@ -231,7 +231,7 @@ function validateFields() {
     errorCount = 0;
 
     //Profile Config
-    checkElementValue("profileNumber", 1, 4, "Must be between 1 and 4", "collapseProfileConfig");
+    checkElementValue("profileNumber", 1, 8, "Must be between 1 and 8", "collapseProfileConfig");
     checkElementString("profileName", 1, 49, "Must be 1 to 49 characters", "collapseProfileConfig");
 
     //GNSS Config

--- a/Firmware/RTK_Surveyor/form.h
+++ b/Firmware/RTK_Surveyor/form.h
@@ -896,6 +896,42 @@ static const char *index_html = R"=====(
                             <p id="profileNameError" class="inlineError"></p>
                         </div>
                     </div>
+
+                    <div class="form-group row mt-2">
+                        <span id="profileList" style="display:inline; margin-left:20px;"><Strong>Profiles</strong></span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile0Name" style="display:inline; margin-left:40px;">1: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile1Name" style="display:inline; margin-left:40px;">2: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile2Name" style="display:inline; margin-left:40px;">3: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile3Name" style="display:inline; margin-left:40px;">4: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile4Name" style="display:inline; margin-left:40px;">5: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile5Name" style="display:inline; margin-left:40px;">6: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row">
+                        <span id="profile6Name" style="display:inline; margin-left:40px;">7: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+                    <div class="form-group row mb-3">
+                        <span id="profile7Name" style="display:inline; margin-left:40px;">8: 12345678901234567890123456789012345678901234567890</span>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="bootProfileName" class="box-margin20 col-sm-3 col-4 col-form-label">Boot Profile</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="bootProfileNumber">
+                            <p id="bootProfileNumberError" class="inlineError"></p>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
In the Profile Configuration section:

* Displays the list of profile name
* Displays the boot profile number
* Allows entry of the boot profile number
* When the parameters are saved, updates the boot profile number

Does not update the name in the profile list on WiFi Config page when a profile name is changed.