### PR TITLE
Display Casting Off or Xmitting Off when not connected

### DIFF
--- a/Firmware/RTK_Surveyor/Display.ino
+++ b/Firmware/RTK_Surveyor/Display.ino
@@ -921,6 +921,7 @@ void printTextwithKerning(const char *newText, uint8_t xPos, uint8_t yPos, uint8
 //Show transmission of RTCM correction data packets to NTRIP caster
 void paintRTCM()
 {
+  static uint32_t lastCorrectionDataSeen;
   int textY = 17;
   int textKerning = 8;
   oled.setFont(QW_FONT_8X16);
@@ -935,17 +936,30 @@ void paintRTCM()
     printTextwithKerning("Casting", textX, textY, textKerning);   //via WiFi
   }
 
-  oled.setCursor(0, 39); //x, y
-  oled.setFont(QW_FONT_5X7);
-  oled.print("RTCM:");
-
-  if (rtcmPacketsSent < 100)
-    oled.setCursor(30, 36); //x, y - Give space for two digits
+  //Determine if correction data has been sent recently
+  if (online.txNtripDataCasting)
+    lastCorrectionDataSeen = millis();
+  if ((millis() - lastCorrectionDataSeen) >= 5000)
+  {
+    //No correction data seen
+    oled.setCursor(0, 33); //x, y
+    oled.print("Off");
+  }
   else
-    oled.setCursor(28, 36); //x, y - Push towards colon to make room for log icon
+  {
+    oled.setCursor(0, 39); //x, y
+    oled.setFont(QW_FONT_5X7);
+    oled.print("RTCM:");
 
-  oled.setFont(QW_FONT_8X16); //Set font to type 1: 8x16
-  oled.print(rtcmPacketsSent); //rtcmPacketsSent is controlled in processRTCM()
+    if (rtcmPacketsSent < 100)
+      oled.setCursor(30, 36); //x, y - Give space for two digits
+    else
+      oled.setCursor(28, 36); //x, y - Push towards colon to make room for log icon
+
+    oled.setFont(QW_FONT_8X16); //Set font to type 1: 8x16
+    oled.print(rtcmPacketsSent); //rtcmPacketsSent is controlled in processRTCM()
+    online.txNtripDataCasting = false;
+  }
 
   paintResets();
 }

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -357,6 +357,7 @@ void ntripServerProcessRTCM(uint8_t incoming)
       ntripServer->write(incoming); //Send this byte to socket
       ntripServerBytesSent++;
       ntripServerTimer = millis();
+      online.txNtripDataCasting = true;
     }
 
     //Indicate that the GNSS is providing correction data

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -127,7 +127,7 @@ void F9PSerialReadTask(void *e)
       if (length)
         s = serialGNSS.readBytes(rBuffer, length);
 
-      //Account for the byte read
+      //Account for the bytes read
       if (s > 0)
       {
         //Set the next fill offset
@@ -158,8 +158,11 @@ void F9PSerialReadTask(void *e)
           length = sizeof(rBuffer) - rBufferBtOffset;
 
         if ((bluetoothIsCongested() == false) || (settings.throttleDuringSPPCongestion == false))
+        {
           //Push new data to BT SPP if not congested or not throttling
           length = bluetoothWriteBytes(&rBuffer[rBufferBtOffset], length);
+          online.txNtripDataCasting = true;
+        }
         else
         {
           //Don't push data to BT SPP if there is congestion to prevent heap hits.

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -447,8 +447,9 @@ struct struct_online {
   bool battery = false;
   bool accelerometer = false;
   bool ntripClient = false;
-  bool ntripServer = false;
   bool rxRtcmCorrectionData = false;
+  bool ntripServer = false;
+  bool txNtripDataCasting = false;
   bool lband = false;
   bool lbandCorrections = false;
 } online;


### PR DESCRIPTION
When not connected to the NTRIP caster either via Bluetooth or WiFi,
display the Casting Off or Xmitting Off message on the RTK Express, RTK
Express Plus or RTK Facet display.  This occurs when:

*  Using Bluetooth and no Bluetooth connection
*  Using WiFi instead of Bluetooth and no WiFi NTRIP caster connection