### PR TITLE
Fix Bluetooth test hang

### DIFF
--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -385,6 +385,10 @@ void stopUART2Tasks()
     vTaskDelete(F9PSerialWriteTaskHandle);
     F9PSerialWriteTaskHandle = NULL;
   }
+
+  //Give the other CPU time to finish
+  //Eliminates CPU bus hang condition
+  delay(10);
 }
 
 void beginFS()


### PR DESCRIPTION
The hang is most likely a hang in the peripheral bus arbitrator for
UART2 where both CPUs are trying to access UART2, one to set the
baudrate and the other to read another character from the device or
check UART2 status.

Since the tasks are cooperative multitasking it is possible that one of
the UART2 tasks is executing at the time the vTaskDelete call is made.
The vTask call most likely this call only marks the task for deletion,
but does not wait for the deletion of the task.  The task may not get
deleted until it enters the ready state again.

Adding a delay after the vTaskDelete allows the tasks to exit and the
task deletion to complete.  As such, only one task is running that is
attempting to access the UART.

Testing was done by modifying menuSystem in menuSystem.ino to place the
Bluetooth test into a while(1) loop and to print a loop count for each
pass through the test.  Testing has gone on for over 2.5 hours and the
loop count has exceeded 170,000.