### PR TITLE
Add debug menu items to print messages

### DIFF
--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -238,9 +238,18 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%d\n\r", "enablePrintWifiState", settings.enablePrintWifiState);
   settingsFile->printf("%s=%d\n\r", "enablePrintNtripClientState", settings.enablePrintNtripClientState);
   settingsFile->printf("%s=%d\n\r", "enablePrintNtripServerState", settings.enablePrintNtripServerState);
-  settingsFile->printf("%s=%d\n\r", "enablePrintNtripServerRtcm", settings.enablePrintNtripServerRtcm);
   settingsFile->printf("%s=%d\n\r", "enablePrintPosition", settings.enablePrintPosition);
   settingsFile->printf("%s=%d\n\r", "enableMarksFile", settings.enableMarksFile);
+  settingsFile->printf("%s=%d\n\r", "enablePrintBatteryMessages", settings.enablePrintBatteryMessages);
+  settingsFile->printf("%s=%d\n\r", "enablePrintRoverAccuracy", settings.enablePrintRoverAccuracy);
+  settingsFile->printf("%s=%d\n\r", "enablePrintBadMessages", settings.enablePrintBadMessages);
+  settingsFile->printf("%s=%d\n\r", "enablePrintLogFileMessages", settings.enablePrintLogFileMessages);
+  settingsFile->printf("%s=%d\n\r", "enablePrintLogFileStatus", settings.enablePrintLogFileStatus);
+  settingsFile->printf("%s=%d\n\r", "enablePrintRingBufferOffsets", settings.enablePrintRingBufferOffsets);
+  settingsFile->printf("%s=%d\n\r", "enablePrintNtripServerRtcm", settings.enablePrintNtripServerRtcm);
+  settingsFile->printf("%s=%d\n\r", "enablePrintNtripClientRtcm", settings.enablePrintNtripClientRtcm);
+  settingsFile->printf("%s=%d\n\r", "enablePrintStates", settings.enablePrintStates);
+  settingsFile->printf("%s=%d\n\r", "enablePrintDuplicateStates", settings.enablePrintDuplicateStates);
 
   //Record constellation settings
   for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
@@ -809,11 +818,28 @@ bool parseLine(char* str, Settings *settings)
     settings->enablePrintNtripClientState = d;
   else if (strcmp(settingName, "enablePrintNtripServerState") == 0)
     settings->enablePrintNtripServerState = d;
-  else if (strcmp(settingName, "enablePrintNtripServerRtcm") == 0)
-    settings->enablePrintNtripServerRtcm = d;
   else if (strcmp(settingName, "enablePrintPosition") == 0)
     settings->enablePrintPosition = d;
-
+  else if (strcmp(settingName, "enablePrintBatteryMessages") == 0)
+    settings->enablePrintBatteryMessages = d;
+  else if (strcmp(settingName, "enablePrintRoverAccuracy") == 0)
+    settings->enablePrintRoverAccuracy = d;
+  else if (strcmp(settingName, "enablePrintBadMessages") == 0)
+    settings->enablePrintBadMessages = d;
+  else if (strcmp(settingName, "enablePrintLogFileMessages") == 0)
+    settings->enablePrintLogFileMessages = d;
+  else if (strcmp(settingName, "enablePrintLogFileStatus") == 0)
+    settings->enablePrintLogFileStatus = d;
+  else if (strcmp(settingName, "enablePrintRingBufferOffsets") == 0)
+    settings->enablePrintRingBufferOffsets = d;
+  else if (strcmp(settingName, "enablePrintNtripServerRtcm") == 0)
+    settings->enablePrintNtripServerRtcm = d;
+  else if (strcmp(settingName, "enablePrintNtripClientRtcm") == 0)
+    settings->enablePrintNtripClientRtcm = d;
+  else if (strcmp(settingName, "enablePrintStates") == 0)
+    settings->enablePrintStates = d;
+  else if (strcmp(settingName, "enablePrintDuplicateStates") == 0)
+    settings->enablePrintDuplicateStates = d;
   //Check for bulk settings (constellations and message rates)
   //Must be last on else list
   else

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -324,16 +324,43 @@ void menuDebug()
     Serial.print("14) Periodically print NTRIP server state: ");
     Serial.printf("%s\r\n", settings.enablePrintNtripServerState ? "Enabled" : "Disabled");
 
-    Serial.print("15) Print GNSS --> NTRIP caster messages: ");
-    Serial.printf("%s\r\n", settings.enablePrintNtripServerRtcm ? "Enabled" : "Disabled");
-
-    Serial.print("16) Periodically print position: ");
+    Serial.print("15) Periodically print position: ");
     Serial.printf("%s\r\n", settings.enablePrintPosition ? "Enabled" : "Disabled");
 
-    Serial.print("17) Periodically print CPU idle time: ");
+    Serial.print("16) Periodically print CPU idle time: ");
     Serial.printf("%s\r\n", settings.enablePrintIdleTime ? "Enabled" : "Disabled");
 
-    Serial.println("18) Mirror ZED-F9x's UART1 settings to USB");
+    Serial.println("17) Mirror ZED-F9x's UART1 settings to USB");
+
+    Serial.print("18) Print battery status messages: ");
+    Serial.printf("%s\r\n", settings.enablePrintBatteryMessages ? "Enabled" : "Disabled");
+
+    Serial.print("19) Print Rover accuracy messages: ");
+    Serial.printf("%s\r\n", settings.enablePrintRoverAccuracy ? "Enabled" : "Disabled");
+
+    Serial.print("20) Print messages with bad checksums or CRCs: ");
+    Serial.printf("%s\r\n", settings.enablePrintBadMessages ? "Enabled" : "Disabled");
+
+    Serial.print("21) Print log file messages: ");
+    Serial.printf("%s\r\n", settings.enablePrintLogFileMessages ? "Enabled" : "Disabled");
+
+    Serial.print("22) Print log file status: ");
+    Serial.printf("%s\r\n", settings.enablePrintLogFileStatus ? "Enabled" : "Disabled");
+
+    Serial.print("23) Print ring buffer offsets: ");
+    Serial.printf("%s\r\n", settings.enablePrintRingBufferOffsets ? "Enabled" : "Disabled");
+
+    Serial.print("24) Print GNSS --> NTRIP caster messages: ");
+    Serial.printf("%s\r\n", settings.enablePrintNtripServerRtcm ? "Enabled" : "Disabled");
+
+    Serial.print("25) Print NTRIP caster --> GNSS messages: ");
+    Serial.printf("%s\r\n", settings.enablePrintNtripClientRtcm ? "Enabled" : "Disabled");
+
+    Serial.print("26) Print states: ");
+    Serial.printf("%s\r\n", settings.enablePrintStates ? "Enabled" : "Disabled");
+
+    Serial.print("27) Print duplicate states: ");
+    Serial.printf("%s\r\n", settings.enablePrintDuplicateStates ? "Enabled" : "Disabled");
 
     Serial.println("t) Enter Test Screen");
 
@@ -457,17 +484,13 @@ void menuDebug()
       }
       else if (incoming == 15)
       {
-        settings.enablePrintNtripServerRtcm ^= 1;
+        settings.enablePrintPosition ^= 1;
       }
       else if (incoming == 16)
       {
-        settings.enablePrintPosition ^= 1;
-      }
-      else if (incoming == 17)
-      {
         settings.enablePrintIdleTime ^= 1;
       }
-      else if (incoming == 18)
+      else if (incoming == 17)
       {
         bool response = configureGNSSMessageRates(COM_PORT_USB, settings.ubxMessages); //Make sure the appropriate messages are enabled
         response &= i2cGNSS.setPortOutput(COM_PORT_USB, COM_TYPE_NMEA | COM_TYPE_UBX | COM_TYPE_RTCM3); //Duplicate UART1
@@ -476,6 +499,46 @@ void menuDebug()
           Serial.println(F("Failed to enable USB messages"));
         else
           Serial.println(F("USB messages successfully enabled"));
+      }
+      else if (incoming == 18)
+      {
+        settings.enablePrintBatteryMessages ^= 1;
+      }
+      else if (incoming == 19)
+      {
+        settings.enablePrintRoverAccuracy ^= 1;
+      }
+      else if (incoming == 20)
+      {
+        settings.enablePrintBadMessages ^= 1;
+      }
+      else if (incoming == 21)
+      {
+        settings.enablePrintLogFileMessages ^= 1;
+      }
+      else if (incoming == 22)
+      {
+        settings.enablePrintLogFileStatus ^= 1;
+      }
+      else if (incoming == 23)
+      {
+        settings.enablePrintRingBufferOffsets ^= 1;
+      }
+      else if (incoming == 24)
+      {
+        settings.enablePrintNtripServerRtcm ^= 1;
+      }
+      else if (incoming == 25)
+      {
+        settings.enablePrintNtripClientRtcm ^= 1;
+      }
+      else if (incoming == 26)
+      {
+        settings.enablePrintStates ^= 1;
+      }
+      else if (incoming == 27)
+      {
+        settings.enablePrintDuplicateStates ^= 1;
       }
       else
         printUnknown(incoming);

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -429,9 +429,18 @@ typedef struct {
   bool enablePrintWifiState = false;
   bool enablePrintNtripClientState = false;
   bool enablePrintNtripServerState = false;
-  bool enablePrintNtripServerRtcm = false;
   bool enablePrintPosition = false;
   bool enablePrintIdleTime = false;
+  bool enablePrintBatteryMessages = true;
+  bool enablePrintRoverAccuracy = true;
+  bool enablePrintBadMessages = false;
+  bool enablePrintLogFileMessages = false;
+  bool enablePrintLogFileStatus = true;
+  bool enablePrintRingBufferOffsets = false;
+  bool enablePrintNtripServerRtcm = false;
+  bool enablePrintNtripClientRtcm = false;
+  bool enablePrintStates = true;
+  bool enablePrintDuplicateStates = false;
 } Settings;
 Settings settings;
 


### PR DESCRIPTION
Add debug menu items to print:
* Battery messages
* Rover Accuracy messages
* Messages with bad checksums or CRCs
* Log file messages
* NTRIP server messages (already in debug menu)
* NTRIP client messages