### PR TITLE
Reset the maximum logging time when logging is disabled

### DIFF
--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -45,6 +45,12 @@ void menuLog()
     if (incoming == '1')
     {
       settings.enableLogging ^= 1;
+
+      //Reset the maximum logging time when logging is disabled to ensure that
+      //the next time logging is enabled that the maximum amount of data can be
+      //captured.
+      if (settings.enableLogging == false)
+        startLogTime_minutes = 0;
     }
     else if (incoming == '2' && settings.enableLogging == true)
     {


### PR DESCRIPTION
Issue detected: Short log file, captured only 40 minutes when the
maximum log time was set to 60 minutes.

Steps to reproduce:
1. Enter the serial configuration
2. Enter 5 to enter the Logging Menu
3. If logging is disabled, enter 1 to enable logging
4. Enter 2 and then 60 to set the maximum log time to 60 minutes
5. If the maximum log length < 60 minutes then enter 3 and enter a value
greater than or equal to 60 for the maximum log length to produce a
single file containing all of the log data
6. Exit the serial configuration menus
7. After about 5 minutes, enter the serial configuration and disable
logging
8. After about another 15 minutes, enter the serial configuration and
enable logging
9. After an hour the logging should have stopped and the last log file
should contain data that is about 40 minutes long, there should also be
a second log file containing about 5 minutes of data.  However, 15
minutes of data was not logged because logging was disabled!

Previous behavior: Maximum log time computed from the time logging was
first enabled either at boot or after manually enabling logging.  If
logging was stopped and then restarted, a new log file would be created
but logging would stop when the maximum logging time was reached,
including the time that logging was disabled.  The data in the log files
would be missing N minutes due to the logging being disabled.

New behavior: Maximum log time is reset when logging is disabled.  When
logging is enabled again, logging would run up to the maximum log time
and the subsequent log files would contain the total specified data.
Once the maximum logging is reached, logging will stop.  Logging can be
manually disabled and enabled or the system rebooted to start logging
again.

If the test above is re-run, there will be two log files, the first
containing about 5 minutes of data and the second containing a full 60
minutes of data.