### PR TITLE
Add log test to debug menu

### DIFF
--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -705,7 +705,6 @@ bool beginExternalTriggers()
 
 void beginIdleTasks()
 {
-#ifdef  COMPILE_IDLE_TASKS
   if (settings.enablePrintIdleTime == true)
   {
     char taskName[32];
@@ -724,7 +723,6 @@ void beginIdleTasks()
           index); //Core where task should run, 0=core, 1=Arduino
     }
   }
-#endif  //COMPILE_IDLE_TASKS
 }
 
 void beginI2C()

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -126,7 +126,7 @@ int startCurrentLogTime_minutes = 0; //Mark when we start this specific log file
 //System crashes if two tasks access a file at the same time
 //So we use a semaphore to see if file system is available
 SemaphoreHandle_t sdCardSemaphore;
-const TickType_t fatSemaphore_shortWait_ms = 10 / portTICK_PERIOD_MS;
+TickType_t fatSemaphore_shortWait_ms = 50 / portTICK_PERIOD_MS;
 const TickType_t fatSemaphore_longWait_ms = 200 / portTICK_PERIOD_MS;
 
 //Display used/free space in menu and config page
@@ -648,8 +648,10 @@ void updateLogs()
   }
   else if (online.logging == true && settings.enableLogging == true && (systemTime_minutes - startCurrentLogTime_minutes) >= settings.maxLogLength_minutes)
   {
-    //Close down file. A new one will be created at the next calling of updateLogs().
-    endSD(false, true);
+    if (settings.runLogTest == false)
+      endSD(false, true); //Close down file. A new one will be created at the next calling of updateLogs().
+    else if (settings.runLogTest == true)
+      updateLogTest();
   }
 
   if (online.logging == true)
@@ -852,8 +854,8 @@ void updateRadio()
         rtcmPacketsSent++; //Assume this is the end of the RTCM frame
 
         esp_now_send(0, (uint8_t *) &espnowOutgoing, espnowOutgoingSpot); //Send partial packet to all peers
-        
-        if(!inMainMenu) log_d("ESPNOW transmitted %d RTCM bytes", espnowBytesSent + espnowOutgoingSpot);
+
+        if (!inMainMenu) log_d("ESPNOW transmitted %d RTCM bytes", espnowBytesSent + espnowOutgoingSpot);
         espnowBytesSent = 0;
         espnowOutgoingSpot = 0; //Reset
       }

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -30,7 +30,6 @@ const int FIRMWARE_VERSION_MINOR = 4;
 #define COMPILE_ESPNOW //Requires WiFi. Comment out to remove ESP-Now functionality.
 #define COMPILE_BT //Comment out to remove Bluetooth functionality
 #define COMPILE_L_BAND //Comment out to remove L-Band functionality
-#define COMPILE_IDLE_TASKS  //Comment out to remove idle tasks
 #define ENABLE_DEVELOPER //Uncomment this line to enable special developer modes (don't check power button at startup)
 
 //Define the RTK board identifier:

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -621,7 +621,6 @@ void ButtonCheckTask(void *e)
   }
 }
 
-#ifdef  COMPILE_IDLE_TASKS
 void idleTask(void *e)
 {
   int cpu = xPortGetCoreID();
@@ -671,4 +670,3 @@ void idleTask(void *e)
     taskYIELD();
   }
 }
-#endif  //COMPILE_IDLE_TASKS

--- a/Firmware/RTK_Surveyor/menuGNSS.ino
+++ b/Firmware/RTK_Surveyor/menuGNSS.ino
@@ -334,7 +334,7 @@ void setMeasurementRates(float secondsBetweenSolutions)
       float measurementFrequency = (1000.0 / settings.measurementRate) / settings.navigationRate;
       if (measurementFrequency < 1.0) measurementFrequency = 1.0;
 
-      Serial.printf("Adjusting GSV setting to %f\n\r", measurementFrequency);
+      log_d("Adjusting GSV setting to %f", measurementFrequency);
 
       setMessageRateByName("UBX_NMEA_GSV", measurementFrequency); //Update GSV setting in file
       configureMessageRate(COM_PORT_UART1, settings.ubxMessages[8]); //Update rate on module

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -338,6 +338,10 @@ void menuRadio()
 
       Serial.println("2) Pair radios");
       Serial.println("3) Forget all radios");
+#ifdef ENABLE_DEVELOPER
+      Serial.println("4) Add dummy radio");
+      Serial.println("5) Send dummy data");
+#endif
     }
 
     Serial.println("x) Exit");
@@ -406,6 +410,34 @@ void menuRadio()
         Serial.println("Radios forgotten");
       }
     }
+#ifdef ENABLE_DEVELOPER
+    else if (settings.radioType == RADIO_ESPNOW && incoming == 4)
+    {
+      //TODO remove
+      uint8_t peer1[] = {0xB8, 0xD6, 0x1A, 0x0D, 0x8F, 0x9C}; //Facet
+      if (esp_now_is_peer_exist(peer1) == true)
+        log_d("Peer already exists");
+      else
+      {
+        //Add new peer to system
+        espnowAddPeer(peer1);
+
+        //Record this MAC to peer list
+        memcpy(settings.espnowPeers[settings.espnowPeerCount], peer1, 6);
+        settings.espnowPeerCount++;
+        settings.espnowPeerCount %= ESPNOW_MAX_PEERS;
+        recordSystemSettings();
+      }
+
+      espnowSetState(ESPNOW_PAIRED);
+    }
+    else if (settings.radioType == RADIO_ESPNOW && incoming == 5)
+    {
+      //TODO remove
+      uint8_t espnowData[] = "This is the long string to test how quickly we can send one string to the other unit. I am going to need a much longer sentence if I want to get a long amount of data into one transmission. This is nearing 200 characters but needs to be near 250.";
+      esp_now_send(0, (uint8_t *) &espnowData, sizeof(espnowData)); //Send packet to all peers
+    }
+#endif
 
     else if (incoming == STATUS_PRESSED_X)
       break;

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -388,6 +388,9 @@ void menuDebug()
     Serial.print("28) NTRIP server message parser: ");
     Serial.printf("%s\r\n", settings.enableNtripServerMessageParsing ? "Enabled" : "Disabled");
 
+    Serial.print("29) Run Logging Test: ");
+    Serial.printf("%s\r\n", settings.runLogTest ? "Enabled" : "Disabled");
+
     Serial.println("t) Enter Test Screen");
 
     Serial.println("e) Erase LittleFS");
@@ -569,6 +572,15 @@ void menuDebug()
       else if (incoming == 28)
       {
         settings.enableNtripServerMessageParsing ^= 1;
+      }
+      else if (incoming == 29)
+      {
+        settings.runLogTest ^= 1;
+
+        logTestState = LOGTEST_START; //Start test
+
+        //Mark current log file as complete to force test start
+        startCurrentLogTime_minutes = systemTime_minutes - settings.maxLogLength_minutes;
       }
       else
         printUnknown(incoming);

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -177,6 +177,22 @@ typedef enum BluetoothRadioType_e
   BLUETOOTH_RADIO_OFF,
 } BluetoothRadioType_e;
 
+enum LogTestState
+{
+  LOGTEST_START = 0,
+  LOGTEST_4HZ_5MSG_10MS,
+  LOGTEST_4HZ_7MSG_10MS,
+  LOGTEST_10HZ_5MSG_10MS,
+  LOGTEST_10HZ_7MSG_10MS,
+  LOGTEST_4HZ_5MSG_50MS,
+  LOGTEST_4HZ_7MSG_50MS,
+  LOGTEST_10HZ_5MSG_50MS,
+  LOGTEST_10HZ_7MSG_50MS,
+
+  LOGTEST_END,
+} ;
+uint8_t logTestState = LOGTEST_END;
+
 //Radio status LED goes from off (LED off), no connection (blinking), to connected (solid)
 enum BTState
 {
@@ -474,6 +490,7 @@ typedef struct {
   uint8_t espnowPeerCount;
   bool enableNtripServerMessageParsing = false;
   BluetoothRadioType_e bluetoothRadioType = BLUETOOTH_RADIO_SPP;
+  bool runLogTest = false; //When set to true, device will create a series of test logs
 } Settings;
 Settings settings;
 


### PR DESCRIPTION
The log test allows us to record a series of different system configurations into one file. At the same time, we log the output of the ZED via the USB connection. Once complete, the SD log is compared against the USB log to verify both are identical. Be sure to set maxLogLength_minutes before running test. maxLogLength_minutes will set the length of each test.
