### PR TITLE
Properly display and use the MAC addresses

### DIFF
--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -143,8 +143,9 @@ void beginBoard()
   Serial.printf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
 
   //Get unit MAC address
-  esp_read_mac(unitMACAddress, ESP_MAC_WIFI_STA);
-  unitMACAddress[5] += 2; //Convert MAC address to Bluetooth MAC (add 2): https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/system.html#mac-address
+  esp_read_mac(wifiMACAddress, ESP_MAC_WIFI_STA);
+  memcpy(btMACAddress, wifiMACAddress, sizeof(wifiMACAddress));
+  btMACAddress[5] += 2; //Convert MAC address to Bluetooth MAC (add 2): https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/system.html#mac-address
 
   //For all boards, check reset reason. If reset was due to wdt or panic, append last log
   loadSettingsPartial(); //Get resetCount

--- a/Firmware/RTK_Surveyor/Bluetooth.ino
+++ b/Firmware/RTK_Surveyor/Bluetooth.ino
@@ -103,7 +103,7 @@ void bluetoothStart()
     else if(systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING)
       strcpy(stateName, "Base-");
 
-    sprintf(deviceName, "%s %s%02X%02X", platformPrefix, stateName, unitMACAddress[4], unitMACAddress[5]);
+    sprintf(deviceName, "%s %s%02X%02X", platformPrefix, stateName, btMACAddress[4], btMACAddress[5]);
 
     // Select Bluetooth setup
     if (settings.bluetoothRadioType == BLUETOOTH_RADIO_OFF)

--- a/Firmware/RTK_Surveyor/ESPNOW.ino
+++ b/Firmware/RTK_Surveyor/ESPNOW.ino
@@ -249,15 +249,13 @@ esp_err_t espnowSendPairMessage(uint8_t *sendToMac)
   PairMessage pairMessage;
 
   //Get unit MAC address
-  uint8_t unitMACAddress[6];
-  esp_read_mac(unitMACAddress, ESP_MAC_WIFI_STA);
-  memcpy(pairMessage.macAddress, unitMACAddress, 6);
+  memcpy(pairMessage.macAddress, wifiMACAddress, 6);
   pairMessage.encrypt = false;
   pairMessage.channel = 0;
 
   pairMessage.crc = 0; //Calculate CRC
   for (int x = 0 ; x < 6 ; x++)
-    pairMessage.crc += unitMACAddress[x];
+    pairMessage.crc += wifiMACAddress[x];
 
   return (esp_now_send(sendToMac, (uint8_t *) &pairMessage, sizeof(pairMessage))); //Send packet to given MAC
 #else

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -383,7 +383,7 @@ void createSettingsString(char* settingsCSV)
 
   //L-Band
   char hardwareID[13];
-  sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", unitMACAddress[0], unitMACAddress[1], unitMACAddress[2], unitMACAddress[3], unitMACAddress[4], unitMACAddress[5]); //Get ready for JSON
+  sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", lbandMACAddress[0], lbandMACAddress[1], lbandMACAddress[2], lbandMACAddress[3], lbandMACAddress[4], lbandMACAddress[5]); //Get ready for JSON
   stringRecord(settingsCSV, "hardwareID", hardwareID);
 
   char apDaysRemaining[20];

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -367,7 +367,9 @@ const uint8_t ESPNOW_MAX_PEERS = 5; //Maximum of 5 rovers
 
 //Global variables
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-uint8_t unitMACAddress[6]; //Use MAC address in BT broadcast and display
+#define lbandMACAddress         btMACAddress
+uint8_t wifiMACAddress[6]; //Display this address in the system menu
+uint8_t btMACAddress[6];   //Display this address when Bluetooth is enabled, otherwise display wifiMACAddress
 char deviceName[70]; //The serial string that is broadcast. Ex: 'Surveyor Base-BC61'
 const byte menuTimeout = 15; //Menus will exit/timeout after this number of seconds
 int systemTime_minutes = 0; //Used to test if logging is less than max minutes

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -311,15 +311,10 @@ void menuRadio()
     if (settings.radioType == RADIO_ESPNOW)
     {
       //Pretty print the MAC of all radios
-
-      //Get unit MAC address
-      uint8_t unitMACAddress[6];
-      esp_read_mac(unitMACAddress, ESP_MAC_WIFI_STA);
-
       Serial.print("  Radio MAC: ");
       for (int x = 0 ; x < 5 ; x++)
-        Serial.printf("%02X:", unitMACAddress[x]);
-      Serial.printf("%02X\n\r", unitMACAddress[5]);
+        Serial.printf("%02X:", wifiMACAddress[x]);
+      Serial.printf("%02X\n\r", wifiMACAddress[5]);
 
       if (settings.espnowPeerCount > 0)
       {

--- a/Firmware/RTK_Surveyor/menuPP.ino
+++ b/Firmware/RTK_Surveyor/menuPP.ino
@@ -170,7 +170,7 @@ bool provisionDevice()
   client.setCACert(AWS_PUBLIC_CERT);
 
   char hardwareID[13];
-  sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", unitMACAddress[0], unitMACAddress[1], unitMACAddress[2], unitMACAddress[3], unitMACAddress[4], unitMACAddress[5]); //Get ready for JSON
+  sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", lbandMACAddress[0], lbandMACAddress[1], lbandMACAddress[2], lbandMACAddress[3], lbandMACAddress[4], lbandMACAddress[5]); //Get ready for JSON
 
 #ifdef WHITELISTED_ID
   //Override ID with testing ID
@@ -882,7 +882,7 @@ void menuPointPerfect()
     Serial.println("Menu: PointPerfect Corrections");
 
     char hardwareID[13];
-    sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", unitMACAddress[0], unitMACAddress[1], unitMACAddress[2], unitMACAddress[3], unitMACAddress[4], unitMACAddress[5]); //Get ready for JSON
+    sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", lbandMACAddress[0], lbandMACAddress[1], lbandMACAddress[2], lbandMACAddress[3], lbandMACAddress[4], lbandMACAddress[5]); //Get ready for JSON
     Serial.printf("Device ID: %s\n\r", hardwareID);
 
     Serial.print("Days until keys expire: ");

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -66,9 +66,9 @@ void menuSystem()
       printNEOInfo();
     }
 
-    //Display MAC address
+    //Display Bluetooth MAC address
     char macAddress[5];
-    sprintf(macAddress, "%02X%02X", unitMACAddress[4], unitMACAddress[5]);
+    sprintf(macAddress, "%02X%02X", btMACAddress[4], btMACAddress[5]);
     Serial.print("Bluetooth (");
     Serial.print(macAddress);
     Serial.print("): ");
@@ -107,6 +107,10 @@ void menuSystem()
     Serial.println();
 
 #ifdef COMPILE_WIFI
+    Serial.print("WiFi MAC Address: ");
+    Serial.printf("%02X-%02X-%02X-%02X-%02X-%02X\r\n", wifiMACAddress[0],
+            wifiMACAddress[1], wifiMACAddress[2], wifiMACAddress[3],
+            wifiMACAddress[4], wifiMACAddress[5]);
     if (wifiState == WIFI_CONNECTED)
       wifiDisplayIpAddress();
 #endif


### PR DESCRIPTION
The ESP32 is assigned 4 MAC addresses but only the base address is
stored in the fuses and is accessible by calling esp_read_mac.  The MAC
address are documented at
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/misc_system_api.html#mac-address:

1. WiFi Station: Base MAC address
2. WiFi AP:      Base MAC address + 1
3. Bluetooth:    Base MAC address + 2
4. Ethernet:     Base MAC address + 3

L-Band is currently using the Bluetooth address for identification but
the code actually use the WiFi Station address when provisioning the
RTK.