### PR TITLE
Restore original delay for UART2 read task

### DIFF
--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -240,7 +240,8 @@ void F9PSerialReadTask(void *e)
     //Let other tasks run, prevent watch dog timer (WDT) resets
     //----------------------------------------------------------------------
 
-    delay(10);
+    delay(1);
+    taskYIELD();
   }
 }
 


### PR DESCRIPTION
Switch task delay from 10 mSec to 1 mSec and add the taskYIELD call.