### PR TITLE
Add NMEA TCP to the ring buffer

### DIFF
--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -267,6 +267,7 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%d\n\r", "espnowPeerCount", settings.espnowPeerCount);
   settingsFile->printf("%s=%d\n\r", "enableRtcmMessageChecking", settings.enableRtcmMessageChecking);
   settingsFile->printf("%s=%d\n\r", "bluetoothRadioType", settings.bluetoothRadioType);
+  settingsFile->printf("%s=%d\n\r", "enableNmeaServer", settings.enableNmeaServer);
 
   //Record constellation settings
   for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
@@ -877,6 +878,8 @@ bool parseLine(char* str, Settings *settings)
     settings->radioType = (RadioType_e)d;
   else if (strcmp(settingName, "bluetoothRadioType") == 0)
     settings->bluetoothRadioType = (BluetoothRadioType_e)d;
+  else if (strcmp(settingName, "enableNmeaServer") == 0)
+    settings->enableNmeaServer = d;
 
   //Check for bulk settings (constellations, message rates, ESPNOW Peers)
   //Must be last on else list

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -159,6 +159,7 @@ LoggingType loggingType = LOGGING_UNKNOWN;
 
 #endif
 
+volatile uint8_t wifiNmeaConnected;
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 //GNSS configuration

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -177,7 +177,7 @@ void F9PSerialReadTask(void *e)
     {
       //Reduce bytes to send if we have more to send then the end of the buffer
       //We'll wrap next loop
-      if ((btTail + btBytesToSend) >= sizeof(rBuffer))
+      if ((btTail + btBytesToSend) > sizeof(rBuffer))
         btBytesToSend = sizeof(rBuffer) - btTail;
 
       //Push new data to BT SPP if not congested or not throttling
@@ -238,7 +238,7 @@ void F9PSerialReadTask(void *e)
         {
           //Reduce bytes to send if we have more to send then the end of the buffer
           //We'll wrap next loop
-          if ((sdTail + sdBytesToRecord) >= sizeof(rBuffer))
+          if ((sdTail + sdBytesToRecord) > sizeof(rBuffer))
             sdBytesToRecord = sizeof(rBuffer) - sdTail;
 
           //Write the data to the file

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -39,9 +39,11 @@ void F9PSerialReadTask(void *e)
   static uint8_t rBuffer[1024 * 6]; //Buffer for reading from F9P to SPP
   static uint16_t dataHead = 0; //Head advances as data comes in from GNSS's UART
   static uint16_t btTail = 0; //BT Tail advances as it is sent over BT
+  static uint16_t nmeaTail = 0; //NMEA TCP client tail
   static uint16_t sdTail = 0; //SD Tail advances as it is recorded to SD
 
   int btBytesToSend; //Amount of buffered Bluetooth data
+  int nmeaBytesToSend; //Amount of buffered NMEA TCP data
   int sdBytesToRecord; //Amount of buffered microSD card logging data
   int availableBufferSpace; //Distance between head and furthest away tail
 
@@ -106,6 +108,15 @@ void F9PSerialReadTask(void *e)
         btBytesToSend += sizeof(rBuffer);
     }
 
+    //Determine the amount of NMEA TCP data in the buffer
+    nmeaBytesToSend = 0;
+    if (settings.enableNmeaServer)
+    {
+      nmeaBytesToSend = dataHead - nmeaTail;
+      if (nmeaBytesToSend < 0)
+        nmeaBytesToSend += sizeof(rBuffer);
+    }
+
     //Determine the amount of microSD card logging data in the buffer
     sdBytesToRecord = 0;
     if (online.logging)
@@ -150,6 +161,8 @@ void F9PSerialReadTask(void *e)
         btBytesToSend += newBytesToRecord;
       if (online.logging)
         sdBytesToRecord += newBytesToRecord;
+      if (online.nmeaServer && wifiNmeaConnected)
+        nmeaBytesToSend += newBytesToRecord;
     } //End Serial.available()
 
     //----------------------------------------------------------------------
@@ -182,6 +195,28 @@ void F9PSerialReadTask(void *e)
       }
       else
         log_w("BT failed to send");
+    }
+
+    //----------------------------------------------------------------------
+    //Send data to the NMEA clients
+    //----------------------------------------------------------------------
+
+    if (!settings.enableNmeaServer && (!wifiNmeaConnected))
+      nmeaTail = dataHead;
+    else
+    {
+      //Reduce bytes to send if we have more to send then the end of the buffer
+      //We'll wrap next loop
+      if ((nmeaTail + nmeaBytesToSend) > sizeof(rBuffer))
+        nmeaBytesToSend = sizeof(rBuffer) - nmeaTail;
+
+      //Send the data to the NMEA TCP clients
+      wifiNmeaData (&rBuffer[nmeaTail], nmeaBytesToSend);
+
+      //Assume all data was sent, wrap the buffer pointer
+      nmeaTail += nmeaBytesToSend;
+      if (nmeaTail >= sizeof(rBuffer))
+        nmeaTail -= sizeof(rBuffer);
     }
 
     //----------------------------------------------------------------------

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -193,6 +193,16 @@ void menuSystem()
     {
       //Toggle WiFi NEMA server
       settings.enableNmeaServer ^= 1;
+      if ((!settings.enableNmeaServer) && online.nmeaServer)
+      {
+        //Tell the UART2 tasks that the NMEA server is shutting down
+        online.nmeaServer = false;
+
+        //Wait for the UART2 tasks to close the NMEA client connections
+        while (wifiNmeaTcpServerActive())
+          delay(5);
+        Serial.println("NMEA Server offline");
+      }
     }
     else if (incoming == 'r')
     {

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -126,6 +126,12 @@ void menuSystem()
     else
       Serial.println(F("Off"));
 
+    Serial.print(F("n) Enable/disable WiFi NMEA server: "));
+    if (settings.enableNmeaServer == true)
+      Serial.println(F("Enabled"));
+    else
+      Serial.println(F("Disabled"));
+
     Serial.println("r) Reset all settings to default");
 
     // Support mode switching
@@ -182,6 +188,11 @@ void menuSystem()
       else if (settings.bluetoothRadioType == BLUETOOTH_RADIO_OFF)
         settings.bluetoothRadioType = BLUETOOTH_RADIO_SPP;
       bluetoothStart();
+    }
+    else if (incoming == 'n')
+    {
+      //Toggle WiFi NEMA server
+      settings.enableNmeaServer ^= 1;
     }
     else if (incoming == 'r')
     {
@@ -355,6 +366,9 @@ void menuDebug()
     Serial.printf("%s\r\n", settings.runLogTest ? "Enabled" : "Disabled");
 
     Serial.println("30) Run Bluetooth Test");
+
+    Serial.print("31) Print NMEA TCP status: ");
+    Serial.printf("%s\r\n", settings.enablePrintNmeaTcpStatus ? "Enabled" : "Disabled");
 
     Serial.println("t) Enter Test Screen");
 
@@ -545,6 +559,10 @@ void menuDebug()
       }
       else if (incoming == 30)
         bluetoothTest(true);
+      else if (incoming == 31)
+      {
+        settings.enablePrintNmeaTcpStatus ^= 1;
+      }
       else
         printUnknown(incoming);
     }

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -495,6 +495,8 @@ typedef struct {
   bool enableRtcmMessageChecking = false;
   BluetoothRadioType_e bluetoothRadioType = BLUETOOTH_RADIO_SPP;
   bool runLogTest = false; //When set to true, device will create a series of test logs
+  bool enableNmeaServer = false;
+  bool enablePrintNmeaTcpStatus = false;
 } Settings;
 Settings settings;
 
@@ -514,6 +516,7 @@ struct struct_online {
   bool lband = false;
   bool lbandCorrections = false;
   bool i2c = false;
+  bool nmeaServer = false;
 } online;
 
 #ifdef COMPILE_WIFI


### PR DESCRIPTION
Requires #294 through #298

Testing done with Bluetooth disabled:
    * Verified client disconnect is detected and closes ESP32 NMEA socket
    * Verified disabling NMEA TCP via system menu closes ESP32 NMEA socket
    * Verified wifiStop while NMEA client active closes ESP32 NMEA socket
    * Switching from Rover to Base closes ESP32 NMEA socket
    * Switching from Base to Rover closes ESP32 NMEA socket