### PR TITLE
Enable NMEA TCP client - Connect to phone

### DIFF
--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -267,6 +267,7 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%d\n\r", "espnowPeerCount", settings.espnowPeerCount);
   settingsFile->printf("%s=%d\n\r", "enableRtcmMessageChecking", settings.enableRtcmMessageChecking);
   settingsFile->printf("%s=%d\n\r", "bluetoothRadioType", settings.bluetoothRadioType);
+  settingsFile->printf("%s=%d\n\r", "enableNmeaClient", settings.enableNmeaClient);
   settingsFile->printf("%s=%d\n\r", "enableNmeaServer", settings.enableNmeaServer);
 
   //Record constellation settings
@@ -878,6 +879,8 @@ bool parseLine(char* str, Settings *settings)
     settings->radioType = (RadioType_e)d;
   else if (strcmp(settingName, "bluetoothRadioType") == 0)
     settings->bluetoothRadioType = (BluetoothRadioType_e)d;
+  else if (strcmp(settingName, "enableNmeaClient") == 0)
+    settings->enableNmeaClient = d;
   else if (strcmp(settingName, "enableNmeaServer") == 0)
     settings->enableNmeaServer = d;
 

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -267,6 +267,7 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%d\n\r", "espnowPeerCount", settings.espnowPeerCount);
   settingsFile->printf("%s=%d\n\r", "enableRtcmMessageChecking", settings.enableRtcmMessageChecking);
   settingsFile->printf("%s=%d\n\r", "bluetoothRadioType", settings.bluetoothRadioType);
+  settingsFile->printf("%s=%d\n\r", "enableNmeaServer", settings.enableNmeaServer);
 
   //Record constellation settings
   for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
@@ -877,6 +878,8 @@ bool parseLine(char* str, Settings *settings)
     settings->radioType = (RadioType_e)d;
   else if (strcmp(settingName, "bluetoothRadioType") == 0)
     settings->bluetoothRadioType = (BluetoothRadioType_e)d;
+  else if (strcmp(settingName, "enableNmeaServer") == 0)
+    settings->enableNmeaServer = d;
 
   //Check for bulk settings (constellations, message rates, ESPNOW Peers)
   //Must be last on else list

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -159,6 +159,7 @@ LoggingType loggingType = LOGGING_UNKNOWN;
 
 #endif
 
+volatile uint8_t wifiNmeaConnected;
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 //GNSS configuration

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -39,9 +39,11 @@ void F9PSerialReadTask(void *e)
   static uint8_t rBuffer[1024 * 6]; //Buffer for reading from F9P to SPP
   static uint16_t dataHead = 0; //Head advances as data comes in from GNSS's UART
   static uint16_t btTail = 0; //BT Tail advances as it is sent over BT
+  static uint16_t nmeaTail = 0; //NMEA TCP client tail
   static uint16_t sdTail = 0; //SD Tail advances as it is recorded to SD
 
   int btBytesToSend; //Amount of buffered Bluetooth data
+  int nmeaBytesToSend; //Amount of buffered NMEA TCP data
   int sdBytesToRecord; //Amount of buffered microSD card logging data
   int availableBufferSpace; //Distance between head and furthest away tail
 
@@ -106,6 +108,15 @@ void F9PSerialReadTask(void *e)
         btBytesToSend += sizeof(rBuffer);
     }
 
+    //Determine the amount of NMEA TCP data in the buffer
+    nmeaBytesToSend = 0;
+    if (settings.enableNmeaServer)
+    {
+      nmeaBytesToSend = dataHead - nmeaTail;
+      if (nmeaBytesToSend < 0)
+        nmeaBytesToSend += sizeof(rBuffer);
+    }
+
     //Determine the amount of microSD card logging data in the buffer
     sdBytesToRecord = 0;
     if (online.logging)
@@ -150,6 +161,8 @@ void F9PSerialReadTask(void *e)
         btBytesToSend += newBytesToRecord;
       if (online.logging)
         sdBytesToRecord += newBytesToRecord;
+      if (online.nmeaServer && wifiNmeaConnected)
+        nmeaBytesToSend += newBytesToRecord;
     } //End Serial.available()
 
     //----------------------------------------------------------------------
@@ -182,6 +195,28 @@ void F9PSerialReadTask(void *e)
       }
       else
         log_w("BT failed to send");
+    }
+
+    //----------------------------------------------------------------------
+    //Send data to the NMEA clients
+    //----------------------------------------------------------------------
+
+    if (!settings.enableNmeaServer && (!wifiNmeaConnected))
+      nmeaTail = dataHead;
+    else
+    {
+      //Reduce bytes to send if we have more to send then the end of the buffer
+      //We'll wrap next loop
+      if ((nmeaTail + nmeaBytesToSend) > sizeof(rBuffer))
+        nmeaBytesToSend = sizeof(rBuffer) - nmeaTail;
+
+      //Send the data to the NMEA TCP clients
+      wifiNmeaData (&rBuffer[nmeaTail], nmeaBytesToSend);
+
+      //Assume all data was sent, wrap the buffer pointer
+      nmeaTail += nmeaBytesToSend;
+      if (nmeaTail >= sizeof(rBuffer))
+        nmeaTail -= sizeof(rBuffer);
     }
 
     //----------------------------------------------------------------------

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -50,191 +50,189 @@ void F9PSerialReadTask(void *e)
 
   while (true)
   {
-    while (serialGNSS.available())
+    if (settings.enableTaskReports == true)
+      Serial.printf("SerialReadTask High watermark: %d\n\r",  uxTaskGetStackHighWaterMark(NULL));
+
+    //----------------------------------------------------------------------
+    //The ESP32<->ZED-F9P serial connection is default 460,800bps to facilitate
+    //10Hz fix rate with PPP Logging Defaults (NMEAx5 + RXMx2) messages enabled.
+    //ESP32 UART2 is begun with SERIAL_SIZE_RX size buffer. The circular buffer
+    //is 1024*6. At approximately 46.1K characters/second, a 6144 * 2
+    //byte buffer should hold 267ms worth of serial data. Assuming SD writes are
+    //250ms worst case, we should record incoming all data. Bluetooth congestion
+    //or conflicts with the SD card semaphore should clear within this time.
+    //
+    //Ring buffer empty when (dataHead == btTail) and (dataHead == sdTail)
+    //
+    //        +---------+
+    //        |         |
+    //        |         |
+    //        |         |
+    //        |         |
+    //        +---------+ <-- dataHead, btTail, sdTail
+    //
+    //Ring buffer contains data when (dataHead != btTail) or (dataHead != sdTail)
+    //
+    //        +---------+
+    //        |         |
+    //        |         |
+    //        | yyyyyyy | <-- dataHead
+    //        | xxxxxxx | <-- btTail (1 byte in buffer)
+    //        +---------+ <-- sdTail (2 bytes in buffer)
+    //
+    //        +---------+
+    //        | yyyyyyy | <-- btTail (1 byte in buffer)
+    //        | xxxxxxx | <-- sdTail (2 bytes in buffer)
+    //        |         |
+    //        |         |
+    //        +---------+ <-- dataHead
+    //
+    //Maximum ring buffer fill is sizeof(rBuffer) - 1
+    //----------------------------------------------------------------------
+
+    //Determine BT connection state
+    btConnected = (bluetoothGetState() == BT_CONNECTED)
+                  && (systemState != STATE_BASE_TEMP_SETTLE)
+                  && (systemState != STATE_BASE_TEMP_SURVEY_STARTED);
+
+    availableBufferSpace = sizeof(rBuffer);
+
+    //Determine the amount of Bluetooth data in the buffer
+    btBytesToSend = 0;
+    if (btConnected)
     {
-      if (settings.enableTaskReports == true)
-        Serial.printf("SerialReadTask High watermark: %d\n\r",  uxTaskGetStackHighWaterMark(NULL));
+      btBytesToSend = dataHead - btTail;
+      if (btBytesToSend < 0)
+        btBytesToSend += sizeof(rBuffer);
+    }
 
-      //----------------------------------------------------------------------
-      //The ESP32<->ZED-F9P serial connection is default 460,800bps to facilitate
-      //10Hz fix rate with PPP Logging Defaults (NMEAx5 + RXMx2) messages enabled.
-      //ESP32 UART2 is begun with SERIAL_SIZE_RX size buffer. The circular buffer
-      //is 1024*6. At approximately 46.1K characters/second, a 6144 * 2
-      //byte buffer should hold 267ms worth of serial data. Assuming SD writes are
-      //250ms worst case, we should record incoming all data. Bluetooth congestion
-      //or conflicts with the SD card semaphore should clear within this time.
-      //
-      //Ring buffer empty when (dataHead == btTail) and (dataHead == sdTail)
-      //
-      //        +---------+
-      //        |         |
-      //        |         |
-      //        |         |
-      //        |         |
-      //        +---------+ <-- dataHead, btTail, sdTail
-      //
-      //Ring buffer contains data when (dataHead != btTail) or (dataHead != sdTail)
-      //
-      //        +---------+
-      //        |         |
-      //        |         |
-      //        | yyyyyyy | <-- dataHead
-      //        | xxxxxxx | <-- btTail (1 byte in buffer)
-      //        +---------+ <-- sdTail (2 bytes in buffer)
-      //
-      //        +---------+
-      //        | yyyyyyy | <-- btTail (1 byte in buffer)
-      //        | xxxxxxx | <-- sdTail (2 bytes in buffer)
-      //        |         |
-      //        |         |
-      //        +---------+ <-- dataHead
-      //
-      //Maximum ring buffer fill is sizeof(rBuffer) - 1
-      //----------------------------------------------------------------------
+    //Determine the amount of microSD card logging data in the buffer
+    sdBytesToRecord = 0;
+    if (online.logging)
+    {
+      sdBytesToRecord = dataHead - sdTail;
+      if (sdBytesToRecord < 0)
+        sdBytesToRecord += sizeof(rBuffer);
+    }
 
-      availableBufferSpace = sizeof(rBuffer);
+    //Determine the free bytes in the buffer
+    if (btBytesToSend >= sdBytesToRecord)
+      availableBufferSpace = sizeof(rBuffer) - btBytesToSend;
+    else
+      availableBufferSpace = sizeof(rBuffer) - sdBytesToRecord;
 
-      //Determine BT connection state
-      btConnected = (bluetoothGetState() == BT_CONNECTED)
-                    && (systemState != STATE_BASE_TEMP_SETTLE)
-                    && (systemState != STATE_BASE_TEMP_SURVEY_STARTED);
+    //Don't fill the last byte to prevent buffer overflow
+    if (availableBufferSpace)
+      availableBufferSpace -= 1;
 
-      //Determine the amount of Bluetooth data in the buffer
-      btBytesToSend = 0;
-      if (btConnected)
-      {
-        btBytesToSend = dataHead - btTail;
-        if (btBytesToSend < 0)
-          btBytesToSend += sizeof(rBuffer);
-      }
-
-      //Determine the amount of microSD card logging data in the buffer
-      sdBytesToRecord = 0;
-      if (online.logging)
-      {
-        sdBytesToRecord = dataHead - sdTail;
-        if (sdBytesToRecord < 0)
-          sdBytesToRecord += sizeof(rBuffer);
-      }
-
-      //Determine the free bytes in the buffer
-      if (btBytesToSend >= sdBytesToRecord)
-        availableBufferSpace = sizeof(rBuffer) - btBytesToSend;
-      else
-        availableBufferSpace = sizeof(rBuffer) - sdBytesToRecord;
-
-      //Don't fill the last byte to prevent buffer overflow
-      if (availableBufferSpace)
-        availableBufferSpace -= 1;
-
+    //While there is free buffer space and UART2 has at least one RX byte
+    while (availableBufferSpace && serialGNSS.available())
+    {
       //Fill the buffer to the end and then start at the beginning
       if ((dataHead + availableBufferSpace) >= sizeof(rBuffer))
         availableBufferSpace = sizeof(rBuffer) - dataHead;
 
-      //If we have buffer space, read data from the GNSS into the buffer
-      newBytesToRecord = 0;
-      if (availableBufferSpace)
+      //Add new data into circular buffer in front of the head
+      //availableBufferSpace is already reduced to avoid buffer overflow
+      newBytesToRecord = serialGNSS.readBytes(&rBuffer[dataHead], availableBufferSpace);
+
+      //Account for the bytes read
+      if (newBytesToRecord <= 0)
+        break;
+
+      //Set the next fill offset
+      dataHead += newBytesToRecord;
+      if (dataHead >= sizeof(rBuffer))
+        dataHead -= sizeof(rBuffer);
+
+      //Account for the new data
+      if (btConnected)
+        btBytesToSend += newBytesToRecord;
+      if (online.logging)
+        sdBytesToRecord += newBytesToRecord;
+    } //End Serial.available()
+
+    //----------------------------------------------------------------------
+    //Send data over Bluetooth
+    //----------------------------------------------------------------------
+
+    //If we are actively survey-in then do not pass NMEA data from ZED to phone
+    if (!btConnected)
+      //Discard the data
+      btTail = dataHead;
+    else
+    {
+      //Reduce bytes to send if we have more to send then the end of the buffer
+      //We'll wrap next loop
+      if ((btTail + btBytesToSend) >= sizeof(rBuffer))
+        btBytesToSend = sizeof(rBuffer) - btTail;
+
+      //Push new data to BT SPP if not congested or not throttling
+      btBytesToSend = bluetoothWriteBytes(&rBuffer[btTail], btBytesToSend);
+      if (btBytesToSend > 0)
       {
-        //Add new data into circular buffer in front of the head
-        //availableBufferSpace is already reduced to avoid buffer overflow
-        newBytesToRecord = serialGNSS.readBytes(&rBuffer[dataHead], availableBufferSpace);
-      }
-
-      //Account for the byte read
-      if (newBytesToRecord > 0)
-      {
-        //Set the next fill offset
-        dataHead += newBytesToRecord;
-        if (dataHead >= sizeof(rBuffer))
-          dataHead -= sizeof(rBuffer);
-
-        //Account for the new data
-        if (btConnected)
-          btBytesToSend += newBytesToRecord;
-        if (online.logging)
-          sdBytesToRecord += newBytesToRecord;
-      }
-
-      //----------------------------------------------------------------------
-      //Send data over Bluetooth
-      //----------------------------------------------------------------------
-
-      //If we are actively survey-in then do not pass NMEA data from ZED to phone
-      if (!btConnected)
-        //Discard the data
-        btTail = dataHead;
-      else
-      {
-        //Reduce bytes to send if we have more to send then the end of the buffer
-        //We'll wrap next loop
-        if ((btTail + btBytesToSend) >= sizeof(rBuffer))
-          btBytesToSend = sizeof(rBuffer) - btTail;
-
-        //Push new data to BT SPP if not congested or not throttling
-        btBytesToSend = bluetoothWriteBytes(&rBuffer[btTail], btBytesToSend);
-        if (btBytesToSend > 0)
-        {
-          //If we are in base mode, assume part of the outgoing data is RTCM
-          if (systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING)
-            bluetoothOutgoingRTCM = true;
-        }
-        else
-          log_w("BT failed to send");
-
+        //If we are in base mode, assume part of the outgoing data is RTCM
+        if (systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING)
+          bluetoothOutgoingRTCM = true;
 
         //Account for the sent or dropped data
         btTail += btBytesToSend;
         if (btTail >= sizeof(rBuffer))
           btTail -= sizeof(rBuffer);
       }
-
-      //----------------------------------------------------------------------
-      //Log data to the SD card
-      //----------------------------------------------------------------------
-
-      //If user wants to log, record to SD
-      if (!online.logging)
-        //Discard the data
-        sdTail = dataHead;
       else
+        log_w("BT failed to send");
+    }
+
+    //----------------------------------------------------------------------
+    //Log data to the SD card
+    //----------------------------------------------------------------------
+
+    //If user wants to log, record to SD
+    if (!online.logging)
+      //Discard the data
+      sdTail = dataHead;
+    else
+    {
+      //Check if we are inside the max time window for logging
+      if ((systemTime_minutes - startLogTime_minutes) < settings.maxLogTime_minutes)
       {
-        //Check if we are inside the max time window for logging
-        if ((systemTime_minutes - startLogTime_minutes) < settings.maxLogTime_minutes)
+        //Attempt to gain access to the SD card, avoids collisions with file
+        //writing from other functions like recordSystemSettingsToFile()
+        if (xSemaphoreTake(sdCardSemaphore, loggingSemaphoreWait_ms) == pdPASS)
         {
-          //Attempt to gain access to the SD card, avoids collisions with file
-          //writing from other functions like recordSystemSettingsToFile()
-          if (xSemaphoreTake(sdCardSemaphore, loggingSemaphoreWait_ms) == pdPASS)
-          {
-            //Reduce bytes to send if we have more to send then the end of the buffer
-            //We'll wrap next loop
-            if ((sdTail + sdBytesToRecord) >= sizeof(rBuffer))
-              sdBytesToRecord = sizeof(rBuffer) - sdTail;
+          //Reduce bytes to send if we have more to send then the end of the buffer
+          //We'll wrap next loop
+          if ((sdTail + sdBytesToRecord) >= sizeof(rBuffer))
+            sdBytesToRecord = sizeof(rBuffer) - sdTail;
 
-            //Write the data to the file
-            sdBytesToRecord = ubxFile->write(&rBuffer[sdTail], sdBytesToRecord);
-            xSemaphoreGive(sdCardSemaphore);
+          //Write the data to the file
+          sdBytesToRecord = ubxFile->write(&rBuffer[sdTail], sdBytesToRecord);
+          xSemaphoreGive(sdCardSemaphore);
 
-            //Account for the sent data or dropped
-            sdTail += sdBytesToRecord;
-            if (sdTail >= sizeof(rBuffer))
-              sdTail -= sizeof(rBuffer);
-          } //End sdCardSemaphore
-          else
+          //Account for the sent data or dropped
+          sdTail += sdBytesToRecord;
+          if (sdTail >= sizeof(rBuffer))
+            sdTail -= sizeof(rBuffer);
+        } //End sdCardSemaphore
+        else
+        {
+          //Retry the semaphore a little later if possible
+          if (sdBytesToRecord >= (sizeof(rBuffer) - 1))
           {
-            //Retry the semaphore a little later if possible
-            if (sdBytesToRecord >= (sizeof(rBuffer) - 1))
-            {
-              //Error - no more room in the buffer, drop a buffer's worth of data
-              sdTail = dataHead;
-              log_e("ERROR - sdCardSemaphore failed to yield, Tasks.ino line %d", __LINE__);
-              Serial.printf("ERROR - Dropped %d bytes: GNSS --> log file\r\n", sdBytesToRecord);
-            }
-            else
-              log_w("sdCardSemaphore failed to yield, Tasks.ino line %d", __LINE__);
+            //Error - no more room in the buffer, drop a buffer's worth of data
+            sdTail = dataHead;
+            log_e("ERROR - sdCardSemaphore failed to yield, Tasks.ino line %d", __LINE__);
+            Serial.printf("ERROR - Dropped %d bytes: GNSS --> log file\r\n", sdBytesToRecord);
           }
-        } //End maxLogTime
-      } //End logging
-    } //End Serial.available()
+
+          //Only complain when over half the buffer needs to be written
+          //to the microSD card
+          else if (sdBytesToRecord > (sizeof(rBuffer) / 2))
+            log_w("sdCardSemaphore failed to yield, Tasks.ino line %d", __LINE__);
+        }
+      } //End maxLogTime
+    } //End logging
 
     //----------------------------------------------------------------------
     //Let other tasks run, prevent watch dog timer (WDT) resets

--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -110,7 +110,7 @@ void F9PSerialReadTask(void *e)
 
     //Determine the amount of NMEA TCP data in the buffer
     nmeaBytesToSend = 0;
-    if (settings.enableNmeaServer)
+    if (settings.enableNmeaServer || settings.enableNmeaClient)
     {
       nmeaBytesToSend = dataHead - nmeaTail;
       if (nmeaBytesToSend < 0)
@@ -161,7 +161,7 @@ void F9PSerialReadTask(void *e)
         btBytesToSend += newBytesToRecord;
       if (online.logging)
         sdBytesToRecord += newBytesToRecord;
-      if (online.nmeaServer && wifiNmeaConnected)
+      if ((online.nmeaServer || online.nmeaClient) && wifiNmeaConnected)
         nmeaBytesToSend += newBytesToRecord;
     } //End Serial.available()
 
@@ -201,7 +201,7 @@ void F9PSerialReadTask(void *e)
     //Send data to the NMEA clients
     //----------------------------------------------------------------------
 
-    if (!settings.enableNmeaServer && (!wifiNmeaConnected))
+    if ((!settings.enableNmeaServer) && (!settings.enableNmeaClient) && (!wifiNmeaConnected))
       nmeaTail = dataHead;
     else
     {

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -193,6 +193,16 @@ void menuSystem()
     {
       //Toggle WiFi NEMA server
       settings.enableNmeaServer ^= 1;
+      if ((!settings.enableNmeaServer) && online.nmeaServer)
+      {
+        //Tell the UART2 tasks that the NMEA server is shutting down
+        online.nmeaServer = false;
+
+        //Wait for the UART2 tasks to close the NMEA client connections
+        while (wifiNmeaTcpServerActive())
+          delay(5);
+        Serial.println("NMEA Server offline");
+      }
     }
     else if (incoming == 'r')
     {

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -126,6 +126,12 @@ void menuSystem()
     else
       Serial.println(F("Off"));
 
+    Serial.print(F("n) Enable/disable WiFi NMEA server: "));
+    if (settings.enableNmeaServer == true)
+      Serial.println(F("Enabled"));
+    else
+      Serial.println(F("Disabled"));
+
     Serial.println("r) Reset all settings to default");
 
     // Support mode switching
@@ -182,6 +188,11 @@ void menuSystem()
       else if (settings.bluetoothRadioType == BLUETOOTH_RADIO_OFF)
         settings.bluetoothRadioType = BLUETOOTH_RADIO_SPP;
       bluetoothStart();
+    }
+    else if (incoming == 'n')
+    {
+      //Toggle WiFi NEMA server
+      settings.enableNmeaServer ^= 1;
     }
     else if (incoming == 'r')
     {
@@ -355,6 +366,9 @@ void menuDebug()
     Serial.printf("%s\r\n", settings.runLogTest ? "Enabled" : "Disabled");
 
     Serial.println("30) Run Bluetooth Test");
+
+    Serial.print("31) Print NMEA TCP status: ");
+    Serial.printf("%s\r\n", settings.enablePrintNmeaTcpStatus ? "Enabled" : "Disabled");
 
     Serial.println("t) Enter Test Screen");
 
@@ -545,6 +559,10 @@ void menuDebug()
       }
       else if (incoming == 30)
         bluetoothTest(true);
+      else if (incoming == 31)
+      {
+        settings.enablePrintNmeaTcpStatus ^= 1;
+      }
       else
         printUnknown(incoming);
     }

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -126,6 +126,12 @@ void menuSystem()
     else
       Serial.println(F("Off"));
 
+    Serial.print(F("c) Enable/disable WiFi NMEA client (connect to phone): "));
+    if (settings.enableNmeaClient == true)
+      Serial.println(F("Enabled"));
+    else
+      Serial.println(F("Disabled"));
+
     Serial.print(F("n) Enable/disable WiFi NMEA server: "));
     if (settings.enableNmeaServer == true)
       Serial.println(F("Enabled"));
@@ -188,6 +194,11 @@ void menuSystem()
       else if (settings.bluetoothRadioType == BLUETOOTH_RADIO_OFF)
         settings.bluetoothRadioType = BLUETOOTH_RADIO_SPP;
       bluetoothStart();
+    }
+    else if (incoming == 'c')
+    {
+      //Toggle WiFi NEMA client (connect to phone)
+      settings.enableNmeaClient ^= 1;
     }
     else if (incoming == 'n')
     {

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -495,6 +495,8 @@ typedef struct {
   bool enableRtcmMessageChecking = false;
   BluetoothRadioType_e bluetoothRadioType = BLUETOOTH_RADIO_SPP;
   bool runLogTest = false; //When set to true, device will create a series of test logs
+  bool enableNmeaServer = false;
+  bool enablePrintNmeaTcpStatus = false;
 } Settings;
 Settings settings;
 
@@ -514,6 +516,7 @@ struct struct_online {
   bool lband = false;
   bool lbandCorrections = false;
   bool i2c = false;
+  bool nmeaServer = false;
 } online;
 
 #ifdef COMPILE_WIFI

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -495,6 +495,7 @@ typedef struct {
   bool enableRtcmMessageChecking = false;
   BluetoothRadioType_e bluetoothRadioType = BLUETOOTH_RADIO_SPP;
   bool runLogTest = false; //When set to true, device will create a series of test logs
+  bool enableNmeaClient = false;
   bool enableNmeaServer = false;
   bool enablePrintNmeaTcpStatus = false;
 } Settings;
@@ -516,6 +517,7 @@ struct struct_online {
   bool lband = false;
   bool lbandCorrections = false;
   bool i2c = false;
+  bool nmeaClient = false;
   bool nmeaServer = false;
 } online;
 


### PR DESCRIPTION
Requires: #297, #298, #299
Support using a phone as a WiFi hot spot.  The RTK NMEA TCP client connects to the gateway IP address (the phone's WiFi hot spot) on port 1958.  If an application such as Vespucci is running as a NMEA server using port 1958, then the RTK will connect to the application.
    
Android WiFi Settings
1.  Disable WiFi
2.  Enable Mobile Hot Spot
3.  Set the Network Name
4.  Set the Network Password
5.  Set the Band to 2.4 GHz
6.  Enable Wi-Fi sharing - This enables users of the Hot Spot to talk to applications on the phone

In Vespucci:
1.  Click on the gear icon
2.  Select "Advanced preferences"
3.  Select "Location settings"
4.  Select "GPS/GNSS source"
5.  Select "NMEA from TCP server"
6.  Select "NMEA network source"
7.  Enter an IP address immediately followed by a colon immediately followed by 1958
8.  Click on the OK button
9.  Check the "Leave GPS/GNSS turned off" checkbox
10. Check the "Fallback to network location" checkbox
11. Exit the Location settings menu by clicking on the back arrow "<" symbol
12. Exit the Advanced preferences menu by clicking on the back arrow "<" symbol
13. Exit the Preferences menu by clicking on the back arrow "<" symbol

On the RTK device:
1.  Start the device in Rover mode
2.  Enter Serial Config
3.  Enter '1' to Configure the GNSS Receiver
4.  Enable the NTRIP Client
5.  Enter the WiFi SSID and Password
6.  Set the Caster Address
7.  Set the Caster Port
8.  Set the Caster User Name
9.  Set the Mountpoint
10. Set the Mountpoint Password
11. Exit the GNSS menu
12. Enter 's' to enter the System menu
13. Enter 'c' to enable the NMEA TCP client (connect to phone)
14. Exit the System menu
15. Exit the Main menu