### PR TITLE
Allocate and free the L-Band context buffers

### DIFF
--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -159,10 +159,6 @@ LoggingType loggingType = LOGGING_UNKNOWN;
 
 #endif
 
-//char *certificateContents; //Holds the contents of the keys prior to MQTT connection
-//char *keyContents;
-char certificateContents[2000]; //Holds the contents of the keys prior to MQTT connection
-char keyContents[2000];
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 //GNSS configuration
@@ -437,7 +433,7 @@ bool restartRover = false; //If user modifies any NTRIP Client settings, we need
 unsigned long startTime = 0; //Used for checking longest running functions
 bool lbandCorrectionsReceived = false; //Used to display L-Band SIV icon when corrections are successfully decrypted
 unsigned long lastLBandDecryption = 0; //Timestamp of last successfully decrypted PMP message
-bool mqttMessageReceived = false; //Goes true when the subscribed MQTT channel reports back
+volatile bool mqttMessageReceived = false; //Goes true when the subscribed MQTT channel reports back
 uint8_t leapSeconds = 0; //Gets set if GNSS is online
 unsigned long systemTestDisplayTime = 0; //Timestamp for swapping the graphic during testing
 uint8_t systemTestDisplayNumber = 0; //Tracks which test screen we're looking at

--- a/Firmware/RTK_Surveyor/menuPP.ino
+++ b/Firmware/RTK_Surveyor/menuPP.ino
@@ -4,6 +4,8 @@
 // Locals - compiled out
 //----------------------------------------
 
+#define CONTENT_SIZE 2000
+
 static SFE_UBLOX_GNSS_ADD i2cLBand; // NEO-D9S
 static const char* pointPerfectKeyTopic = "/pp/ubx/0236/Lb";
 
@@ -281,10 +283,12 @@ bool provisionDevice()
 bool updatePointPerfectKeys()
 {
 #ifdef COMPILE_WIFI
-
+//char *certificateContents; //Holds the contents of the keys prior to MQTT connection
+//char *keyContents;
+  static char certificateContents[CONTENT_SIZE]; //Holds the contents of the keys prior to MQTT connection
+  static char keyContents[CONTENT_SIZE];
   WiFiClientSecure secureClient;
 
-#define CONTENT_SIZE 2000
 
   //certificateContents = (char*)malloc(CONTENT_SIZE);
   //memset(certificateContents, 0, CONTENT_SIZE);
@@ -953,7 +957,7 @@ void menuPointPerfect()
         {
           delay(500);
           Serial.print(".");
-          if (millis() - startTime > 15000) 
+          if (millis() - startTime > 15000)
           {
             Serial.println("Error: No WiFi available");
             break;
@@ -982,7 +986,7 @@ void menuPointPerfect()
             updatePointPerfectKeys();
 
         }
-        
+
         wifiStop();
       } //End strlen SSID check
 #endif

--- a/Firmware/RTK_Surveyor/menuPP.ino
+++ b/Firmware/RTK_Surveyor/menuPP.ino
@@ -283,13 +283,22 @@ bool provisionDevice()
 bool updatePointPerfectKeys()
 {
 #ifdef COMPILE_WIFI
-  static char certificateContents[CONTENT_SIZE]; //Holds the contents of the keys prior to MQTT connection
-  static char keyContents[CONTENT_SIZE];
+  char * certificateContents = NULL; //Holds the contents of the keys prior to MQTT connection
+  char * keyContents = NULL;
   WiFiClientSecure secureClient;
   bool gotKeys = false;
 
   do
   {
+    //Allocate the buffers
+    certificateContents = (char*)malloc(CONTENT_SIZE);
+    keyContents = (char*)malloc(CONTENT_SIZE);
+    if ((!certificateContents) || (!keyContents))
+    {
+      Serial.println("Failed to allocate content buffers!");
+      break;
+    }
+
     //Get the certificate
     memset(certificateContents, 0, CONTENT_SIZE);
     loadFile("certificate", certificateContents);
@@ -378,6 +387,12 @@ bool updatePointPerfectKeys()
     //Done with the MQTT client
     mqttClient.disconnect();
   } while (0);
+
+  //Free the content buffers
+  if (keyContents)
+    free(keyContents);
+  if (certificateContents)
+    free(certificateContents);
 
   //Return the key status
   return (gotKeys);


### PR DESCRIPTION
**This change has not been tested**
`09:32:28.918 -> Connecting to: https://api.thingstream.io/ztp/pointperfect/credentials`
`09:32:28.918 -> HTTP response error 422: {"errors":["token invalid token format"]}`

This change includes:
* Move certificateContents and keyContents into menuPP.ino
* Rework updatePointPerfectKeys to have a single exit
* Always disconnect the MQTT client if it was connected.
* Allocate and free the context buffers