### PR TITLE
Allow system serial over Bluetooth

### DIFF
--- a/Firmware/RTK_Surveyor/Base.ino
+++ b/Firmware/RTK_Surveyor/Base.ino
@@ -71,7 +71,7 @@ bool configureUbloxModuleBase()
   response &= i2cGNSS.sendCfgValset(); //Closing value - #31
 
   if (response == false)
-    Serial.println("Base config fail");
+    systemPrintln("Base config fail");
 
   return (response);
 }
@@ -89,13 +89,13 @@ bool surveyInStart()
 
   if (needSurveyReset == true)
   {
-    Serial.println("Resetting survey");
+    systemPrintln("Resetting survey");
 
     if (surveyInReset() == false)
     {
-      Serial.println("Survey reset failed");
+      systemPrintln("Survey reset failed");
       if (surveyInReset() == false)
-        Serial.println("Survey reset failed - 2nd attempt");
+        systemPrintln("Survey reset failed - 2nd attempt");
     }
   }
 
@@ -106,11 +106,11 @@ bool surveyInStart()
 
   if (response == false)
   {
-    Serial.println("Survey start failed");
+    systemPrintln("Survey start failed");
     return (false);
   }
 
-  Serial.printf("Survey started. This will run until %d seconds have passed and less than %0.03f meter accuracy is achieved.\r\n",
+  systemPrintf("Survey started. This will run until %d seconds have passed and less than %0.03f meter accuracy is achieved.\r\n",
                 settings.observationSeconds,
                 settings.observationPositionAccuracy
                );
@@ -176,9 +176,9 @@ bool startFixedBase()
     long majorEcefZ = floor((settings.fixedEcefZ * 100) + 0.5);
     long minorEcefZ = floor((((settings.fixedEcefZ * 100.0) - majorEcefZ) * 100.0) + 0.5);
 
-    //    Serial.printf("fixedEcefY (should be -4716808.5807): %0.04f\r\n", settings.fixedEcefY);
-    //    Serial.printf("major (should be -471680858): %ld\r\n", majorEcefY);
-    //    Serial.printf("minor (should be -7): %ld\r\n", minorEcefY);
+    //    systemPrintf("fixedEcefY (should be -4716808.5807): %0.04f\r\n", settings.fixedEcefY);
+    //    systemPrintf("major (should be -471680858): %ld\r\n", majorEcefY);
+    //    systemPrintf("minor (should be -7): %ld\r\n", minorEcefY);
 
     //Units are cm with a high precision extension so -1234.5678 should be called: (-123456, -78)
     //-1280208.308,-4716803.847,4086665.811 is SparkFun HQ so...
@@ -208,17 +208,17 @@ bool startFixedBase()
     int32_t majorAlt = totalFixedAltitude * 100;
     int32_t minorAlt = ((totalFixedAltitude * 100) - majorAlt) * 100;
 
-    //    Serial.printf("fixedLong (should be -105.184774720): %0.09f\r\n", settings.fixedLong);
-    //    Serial.printf("major (should be -1051847747): %lld\r\n", majorLat);
-    //    Serial.printf("minor (should be -20): %lld\r\n", minorLat);
+    //    systemPrintf("fixedLong (should be -105.184774720): %0.09f\r\n", settings.fixedLong);
+    //    systemPrintf("major (should be -1051847747): %lld\r\n", majorLat);
+    //    systemPrintf("minor (should be -20): %lld\r\n", minorLat);
     //
-    //    Serial.printf("fixedLat (should be 40.090335429): %0.09f\r\n", settings.fixedLat);
-    //    Serial.printf("major (should be 400903354): %lld\r\n", majorLong);
-    //    Serial.printf("minor (should be 29): %lld\r\n", minorLong);
+    //    systemPrintf("fixedLat (should be 40.090335429): %0.09f\r\n", settings.fixedLat);
+    //    systemPrintf("major (should be 400903354): %lld\r\n", majorLong);
+    //    systemPrintf("minor (should be 29): %lld\r\n", minorLong);
     //
-    //    Serial.printf("fixedAlt (should be 1560.2284): %0.04f\r\n", settings.fixedAltitude);
-    //    Serial.printf("major (should be 156022): %ld\r\n", majorAlt);
-    //    Serial.printf("minor (should be 84): %ld\r\n", minorAlt);
+    //    systemPrintf("fixedAlt (should be 1560.2284): %0.04f\r\n", settings.fixedAltitude);
+    //    systemPrintf("major (should be 156022): %ld\r\n", majorAlt);
+    //    systemPrintf("minor (should be 84): %ld\r\n", minorAlt);
 
     response &= i2cGNSS.newCfgValset8(UBLOX_CFG_TMODE_MODE, 2); //Fixed
     response &= i2cGNSS.addCfgValset8(UBLOX_CFG_TMODE_POS_TYPE, 1); //Position in LLH

--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -140,7 +140,7 @@ void beginBoard()
     }
   }
 
-  Serial.printf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
+  systemPrintf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
 
   //Get unit MAC address
   esp_read_mac(wifiMACAddress, ESP_MAC_WIFI_STA);
@@ -167,24 +167,24 @@ void beginBoard()
     if (settings.enableResetDisplay == true)
     {
       settings.resetCount++;
-      Serial.printf("resetCount: %d\r\n", settings.resetCount);
+      systemPrintf("resetCount: %d\r\n", settings.resetCount);
       recordSystemSettingsToFileLFS(settingsFileName); //Avoid overwriting LittleFS settings onto SD
     }
 
-    Serial.print("Reset reason: ");
+    systemPrint("Reset reason: ");
     switch (esp_reset_reason())
     {
-      case ESP_RST_UNKNOWN: Serial.println("ESP_RST_UNKNOWN"); break;
-      case ESP_RST_POWERON : Serial.println("ESP_RST_POWERON"); break;
-      case ESP_RST_SW : Serial.println("ESP_RST_SW"); break;
-      case ESP_RST_PANIC : Serial.println("ESP_RST_PANIC"); break;
-      case ESP_RST_INT_WDT : Serial.println("ESP_RST_INT_WDT"); break;
-      case ESP_RST_TASK_WDT : Serial.println("ESP_RST_TASK_WDT"); break;
-      case ESP_RST_WDT : Serial.println("ESP_RST_WDT"); break;
-      case ESP_RST_DEEPSLEEP : Serial.println("ESP_RST_DEEPSLEEP"); break;
-      case ESP_RST_BROWNOUT : Serial.println("ESP_RST_BROWNOUT"); break;
-      case ESP_RST_SDIO : Serial.println("ESP_RST_SDIO"); break;
-      default : Serial.println("Unknown");
+      case ESP_RST_UNKNOWN: systemPrintln("ESP_RST_UNKNOWN"); break;
+      case ESP_RST_POWERON : systemPrintln("ESP_RST_POWERON"); break;
+      case ESP_RST_SW : systemPrintln("ESP_RST_SW"); break;
+      case ESP_RST_PANIC : systemPrintln("ESP_RST_PANIC"); break;
+      case ESP_RST_INT_WDT : systemPrintln("ESP_RST_INT_WDT"); break;
+      case ESP_RST_TASK_WDT : systemPrintln("ESP_RST_TASK_WDT"); break;
+      case ESP_RST_WDT : systemPrintln("ESP_RST_WDT"); break;
+      case ESP_RST_DEEPSLEEP : systemPrintln("ESP_RST_DEEPSLEEP"); break;
+      case ESP_RST_BROWNOUT : systemPrintln("ESP_RST_BROWNOUT"); break;
+      case ESP_RST_SDIO : systemPrintln("ESP_RST_SDIO"); break;
+      default : systemPrintln("Unknown");
     }
   }
 }
@@ -245,7 +245,7 @@ void beginSD()
 
     if (settings.spiFrequency > 16)
     {
-      Serial.println("Error: SPI Frequency out of range. Default to 16MHz");
+      systemPrintln("Error: SPI Frequency out of range. Default to 16MHz");
       settings.spiFrequency = 16;
     }
 
@@ -265,7 +265,7 @@ void beginSD()
 
       if (tries == maxTries)
       {
-        Serial.println("SD init failed. Is card formatted?");
+        systemPrintln("SD init failed. Is card formatted?");
         digitalWrite(pin_microSD_CS, HIGH); //Be sure SD is deselected
 
         //Check reset count and prevent rolling reboot
@@ -281,13 +281,13 @@ void beginSD()
     //Change to root directory. All new file creation will be in root.
     if (sd->chdir() == false)
     {
-      Serial.println("SD change directory failed");
+      systemPrintln("SD change directory failed");
       break;
     }
 
     if (createTestFile() == false)
     {
-      Serial.println("Failed to create test file. Format SD card with 'SD Card Formatter'.");
+      systemPrintln("Failed to create test file. Format SD card with 'SD Card Formatter'.");
       displaySDFail(5000);
       break;
     }
@@ -299,7 +299,7 @@ void beginSD()
     sdCardSize = 0;
     outOfSDSpace = true;
 
-    Serial.println("microSD: Online");
+    systemPrintln("microSD: Online");
     online.microSD = true;
     break;
   }
@@ -319,7 +319,7 @@ void endSD(bool alreadyHaveSemaphore, bool releaseSemaphore)
   {
     sd->end();
     online.microSD = false;
-    Serial.println("microSD: Offline");
+    systemPrintln("microSD: Offline");
   }
 
   //Free the caches for the microSD card
@@ -406,11 +406,11 @@ void beginFS()
   {
     if (LittleFS.begin(true) == false) //Format LittleFS if begin fails
     {
-      Serial.println("Error: LittleFS not online");
+      systemPrintln("Error: LittleFS not online");
     }
     else
     {
-      Serial.println("LittleFS Started");
+      systemPrintln("LittleFS Started");
       online.fs = true;
     }
   }
@@ -432,7 +432,7 @@ void beginGNSS()
       return;
     }
   }
-
+  
   //Increase transactions to reduce transfer time
   i2cGNSS.i2cTransactionSize = 128;
 
@@ -464,7 +464,7 @@ void beginGNSS()
       zedFirmwareVersionInt = 132;
     else
     {
-      Serial.printf("Unknown firmware version: %s\r\n", zedFirmwareVersion);
+      systemPrintf("Unknown firmware version: %s\r\n", zedFirmwareVersion);
       zedFirmwareVersionInt = 99; //0.99 invalid firmware version
     }
 
@@ -475,7 +475,7 @@ void beginGNSS()
       zedModuleType = PLATFORM_F9R;
     else
     {
-      Serial.printf("Unknown ZED module: %s\r\n", i2cGNSS.minfo.extension[3]);
+      systemPrintf("Unknown ZED module: %s\r\n", i2cGNSS.minfo.extension[3]);
       zedModuleType = PLATFORM_F9P;
     }
 
@@ -506,20 +506,20 @@ void configureGNSS()
   if (response == false)
   {
     //Try once more
-    Serial.println("Failed to configure GNSS module. Trying again.");
+    systemPrintln("Failed to configure GNSS module. Trying again.");
     delay(1000);
     response = configureUbloxModule();
 
     if (response == false)
     {
-      Serial.println("Failed to configure GNSS module.");
+      systemPrintln("Failed to configure GNSS module.");
       displayGNSSFail(1000);
       online.gnss = false;
       return;
     }
   }
 
-  Serial.println("GNSS configuration complete");
+  systemPrintln("GNSS configuration complete");
 }
 
 //Set LEDs for output and configure PWM
@@ -560,7 +560,7 @@ void beginFuelGauge()
   // Set up the MAX17048 LiPo fuel gauge
   if (lipo.begin() == false)
   {
-    Serial.println("Fuel gauge not detected.");
+    systemPrintln("Fuel gauge not detected.");
     return;
   }
 
@@ -570,14 +570,14 @@ void beginFuelGauge()
   if (lipo.getHIBRTActThr() < 0xFF) lipo.setHIBRTActThr((uint8_t)0xFF);
   if (lipo.getHIBRTHibThr() < 0xFF) lipo.setHIBRTHibThr((uint8_t)0xFF);
 
-  Serial.println("MAX17048 configuration complete");
+  systemPrintln("MAX17048 configuration complete");
 
   checkBatteryLevels(); //Force check so you see battery level immediately at power on
 
   //Check to see if we are dangerously low
   if (battLevel < 5 && battChangeRate < 0.5) //5% and not charging
   {
-    Serial.println("Battery too low. Please charge. Shutting down...");
+    systemPrintln("Battery too low. Please charge. Shutting down...");
 
     if (online.display == true)
       displayMessage("Charge Battery", 0);
@@ -605,7 +605,7 @@ void beginAccelerometer()
   //accel.setDataRate(LIS2DH12_ODR_100Hz); //6 measurements a second
   accel.setDataRate(LIS2DH12_ODR_400Hz); //25 measurements a second
 
-  Serial.println("Accelerometer configuration complete");
+  systemPrintln("Accelerometer configuration complete");
 
   online.accelerometer = true;
 }
@@ -636,7 +636,7 @@ void beginSystemState()
 
     if (systemState > STATE_SHUTDOWN)
     {
-      Serial.println("Unknown state - factory reset");
+      systemPrintln("Unknown state - factory reset");
       factoryReset();
     }
 
@@ -652,7 +652,7 @@ void beginSystemState()
 
     if (systemState > STATE_SHUTDOWN)
     {
-      Serial.println("Unknown state - factory reset");
+      systemPrintln("Unknown state - factory reset");
       factoryReset();
     }
 
@@ -707,7 +707,7 @@ bool beginExternalTriggers()
   response &= i2cGNSS.sendCfgValset32(UBLOX_CFG_TP_LEN_LOCK_TP1, settings.externalPulseLength_us); //Set the pulse length in us
 
   if (response == false)
-    Serial.println("beginExternalTriggers config failed");
+    systemPrintln("beginExternalTriggers config failed");
 
   if (settings.enableExternalHardwareEventLogging == true)
     i2cGNSS.setAutoTIMTM2callback(&eventTriggerReceived); //Enable automatic TIM TM2 messages with callback to eventTriggerReceived
@@ -756,7 +756,7 @@ void beginI2C()
   if (endValue == 2)
     online.i2c = true;
   else
-    Serial.println("Error: I2C Bus Not Responding");
+    systemPrintln("Error: I2C Bus Not Responding");
 }
 
 //Depending on radio selection, begin hardware

--- a/Firmware/RTK_Surveyor/Bluetooth.ino
+++ b/Firmware/RTK_Surveyor/Bluetooth.ino
@@ -39,14 +39,18 @@ static volatile byte bluetoothState = BT_OFF;
 //Used for updating the bluetoothState state machine
 void bluetoothCallback(esp_spp_cb_event_t event, esp_spp_cb_param_t *param) {
   if (event == ESP_SPP_SRV_OPEN_EVT) {
-    Serial.println("BT client Connected");
+    systemPrintln("BT client Connected");
     bluetoothState = BT_CONNECTED;
     if (productVariant == RTK_SURVEYOR)
       digitalWrite(pin_bluetoothStatusLED, HIGH);
   }
 
   if (event == ESP_SPP_CLOSE_EVT ) {
-    Serial.println("BT client disconnected");
+    systemPrintln("BT client disconnected");
+    
+    btPrintEcho = false;
+    printEndpoint = PRINT_ENDPOINT_SERIAL;
+
     bluetoothState = BT_NOTCONNECTED;
     if (productVariant == RTK_SURVEYOR)
       digitalWrite(pin_bluetoothStatusLED, LOW);
@@ -69,11 +73,22 @@ byte bluetoothGetState()
 #endif  //COMPILE_BT
 }
 
+
 //Read data from the Bluetooth device
-int bluetoothReadBytes(uint8_t * buffer, int length)
+int bluetoothRead(uint8_t * buffer, int length)
 {
 #ifdef COMPILE_BT
   return bluetoothSerial->readBytes(buffer, length);
+#else   //COMPILE_BT
+  return 0;
+#endif  //COMPILE_BT
+}
+
+//Read data from the Bluetooth device
+uint8_t bluetoothRead()
+{
+#ifdef COMPILE_BT
+  return bluetoothSerial->read();
 #else   //COMPILE_BT
   return 0;
 #endif  //COMPILE_BT
@@ -86,6 +101,36 @@ bool bluetoothRxDataAvailable()
   return bluetoothSerial->available();
 #else   //COMPILE_BT
   return false;
+#endif  //COMPILE_BT
+}
+
+//Write data to the Bluetooth device
+int bluetoothWrite(const uint8_t *buffer, int length)
+{
+#ifdef COMPILE_BT
+  return bluetoothSerial->write(buffer, length);
+#else   //COMPILE_BT
+  return 0;
+#endif  //COMPILE_BT
+}
+
+//Write data to the Bluetooth device
+int bluetoothWrite(uint8_t value)
+{
+#ifdef COMPILE_BT
+  return bluetoothSerial->write(value);
+#else   //COMPILE_BT
+  return 0;
+#endif  //COMPILE_BT
+}
+
+//Flush Bluetooth device
+void bluetoothFlush()
+{
+#ifdef COMPILE_BT
+  bluetoothSerial->flush();
+#else   //COMPILE_BT
+  return;
 #endif  //COMPILE_BT
 }
 
@@ -115,7 +160,7 @@ void bluetoothStart()
 
     if (bluetoothSerial->begin(deviceName) == false)
     {
-      Serial.println("An error occurred initializing Bluetooth");
+      systemPrintln("An error occurred initializing Bluetooth");
 
       if (productVariant == RTK_SURVEYOR)
         digitalWrite(pin_bluetoothStatusLED, LOW);
@@ -145,8 +190,8 @@ void bluetoothStart()
     bluetoothSerial->register_callback(bluetoothCallback); //Controls BT Status LED on Surveyor
     bluetoothSerial->setTimeout(250);
 
-    Serial.print("Bluetooth broadcasting as: ");
-    Serial.println(deviceName);
+    systemPrint("Bluetooth broadcasting as: ");
+    systemPrintln(deviceName);
 
     //Start task for controlling Bluetooth pair LED
     if (productVariant == RTK_SURVEYOR)
@@ -220,22 +265,11 @@ void bluetoothTest(bool runTest)
   //Display Bluetooth MAC address and test results
   char macAddress[5];
   sprintf(macAddress, "%02X%02X", btMACAddress[4], btMACAddress[5]);
-  Serial.print("Bluetooth ");
+  systemPrint("Bluetooth ");
   if (settings.bluetoothRadioType == BLUETOOTH_RADIO_BLE)
-    Serial.print("Low Energy ");
-  Serial.print("(");
-  Serial.print(macAddress);
-  Serial.print("): ");
-  Serial.println(bluetoothStatusText);
-}
-
-//Write data to the Bluetooth device
-int bluetoothWriteBytes(const uint8_t * buffer, int length)
-{
-#ifdef COMPILE_BT
-  //Push new data to BT SPP
-  return bluetoothSerial->write(buffer, length);
-#else   //COMPILE_BT
-  return 0;
-#endif  //COMPILE_BT
+    systemPrint("Low Energy ");
+  systemPrint("(");
+  systemPrint(macAddress);
+  systemPrint("): ");
+  systemPrintln(bluetoothStatusText);
 }

--- a/Firmware/RTK_Surveyor/Display.ino
+++ b/Firmware/RTK_Surveyor/Display.ino
@@ -94,7 +94,7 @@ void beginDisplay()
     {
       online.display = true;
 
-      Serial.println("Display started");
+      systemPrintln("Display started");
 
       //Display the SparkFun LOGO
       oled.erase();
@@ -107,7 +107,7 @@ void beginDisplay()
     delay(50); //Give display time to startup before attempting again
   }
 
-  Serial.println("Display not detected");
+  systemPrintln("Display not detected");
 }
 
 //Given the system state, display the appropriate information
@@ -342,7 +342,7 @@ void updateDisplay()
           displayShutdown();
           break;
         default:
-          Serial.printf("Unknown display: %d\r\n", systemState);
+          systemPrintf("Unknown display: %d\r\n", systemState);
           displayError("Display");
           break;
       }
@@ -1930,7 +1930,7 @@ void paintSystemTest()
       //Verify the ESP UART2 can communicate TX/RX to ZED UART1
       if (zedUartPassed == false)
       {
-        Serial.println("GNSS test");
+        systemPrintln("GNSS test");
 
         setMuxport(MUX_UBLOX_NMEA); //Set mux to UART so we can debug over data port
         delay(20);

--- a/Firmware/RTK_Surveyor/ESPNOW.ino
+++ b/Firmware/RTK_Surveyor/ESPNOW.ino
@@ -25,11 +25,11 @@ typedef struct PairMessage {
 #ifdef COMPILE_ESPNOW
 void espnowOnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status)
 {
-  //  Serial.print("Last Packet Send Status: ");
+  //  systemPrint("Last Packet Send Status: ");
   //  if (status == ESP_NOW_SEND_SUCCESS)
-  //    Serial.println("Delivery Success");
+  //    systemPrintln("Delivery Success");
   //  else
-  //    Serial.println("Delivery Fail");
+  //    systemPrintln("Delivery Fail");
 }
 #endif
 
@@ -120,7 +120,7 @@ void espnowStart()
 
   // Init ESP-NOW
   if (esp_now_init() != ESP_OK) {
-    Serial.println("Error starting ESP-Now");
+    systemPrintln("Error starting ESP-Now");
     return;
   }
 
@@ -170,7 +170,7 @@ void espnowStart()
     }
   }
 
-  Serial.println("ESP-Now Started");
+  systemPrintln("ESP-Now Started");
 #endif
 }
 
@@ -191,7 +191,7 @@ void espnowStop()
 
   // Deinit ESP-NOW
   if (esp_now_deinit() != ESP_OK) {
-    Serial.println("Error deinitializing ESP-NOW");
+    systemPrintln("Error deinitializing ESP-NOW");
     return;
   }
 
@@ -341,29 +341,29 @@ esp_err_t espnowRemovePeer(uint8_t *peerMac)
 void espnowSetState(ESPNOWState newState)
 {
   if (espnowState == newState)
-    Serial.print("*");
+    systemPrint("*");
   espnowState = newState;
 
-  Serial.print("espnowState: ");
+  systemPrint("espnowState: ");
   switch (newState)
   {
     case ESPNOW_OFF:
-      Serial.println("ESPNOW_OFF");
+      systemPrintln("ESPNOW_OFF");
       break;
     case ESPNOW_ON:
-      Serial.println("ESPNOW_ON");
+      systemPrintln("ESPNOW_ON");
       break;
     case ESPNOW_PAIRING:
-      Serial.println("ESPNOW_PAIRING");
+      systemPrintln("ESPNOW_PAIRING");
       break;
     case ESPNOW_MAC_RECEIVED:
-      Serial.println("ESPNOW_MAC_RECEIVED");
+      systemPrintln("ESPNOW_MAC_RECEIVED");
       break;
     case ESPNOW_PAIRED:
-      Serial.println("ESPNOW_PAIRED");
+      systemPrintln("ESPNOW_PAIRED");
       break;
     default:
-      Serial.printf("Unknown ESPNOW state: %d\r\n", newState);
+      systemPrintf("Unknown ESPNOW state: %d\r\n", newState);
       break;
   }
 }
@@ -403,7 +403,7 @@ void espnowProcessRTCM(byte incoming)
 //either through the serial menu or AP config
 void espnowStaticPairing()
 {
-  Serial.println("Begin ESP NOW Pairing");
+  systemPrintln("Begin ESP NOW Pairing");
 
   //Start ESP-Now if needed, put ESP-Now into broadcast state
   espnowBeginPairing();
@@ -411,7 +411,7 @@ void espnowStaticPairing()
   //Begin sending our MAC every 250ms until a remote device sends us there info
   randomSeed(millis());
 
-  Serial.println("Begin pairing. Place other unit in pairing mode. Press any key to exit.");
+  systemPrintln("Begin pairing. Place other unit in pairing mode. Press any key to exit.");
   clearBuffer();
 
   uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
@@ -421,7 +421,7 @@ void espnowStaticPairing()
   {
     if (Serial.available())
     {
-      Serial.println("User pressed button. Pairing canceled.");
+      systemPrintln("User pressed button. Pairing canceled.");
       break;
     }
 
@@ -432,7 +432,7 @@ void espnowStaticPairing()
 
       if (espnowIsPaired() == true) //Check if we've received a pairing message
       {
-        Serial.println("Pairing compete");
+        systemPrintln("Pairing compete");
         exitPair = true;
         break;
       }
@@ -440,6 +440,6 @@ void espnowStaticPairing()
 
     espnowSendPairMessage(broadcastMac); //Send unit's MAC address over broadcast, no ack, no encryption
 
-    Serial.println("Scanning for other radio...");
+    systemPrintln("Scanning for other radio...");
   }
 }

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -127,7 +127,7 @@ void startWebServer()
   webserver->on("/listfiles", HTTP_GET, [](AsyncWebServerRequest * request)
   {
     String logmessage = "Client:" + request->client()->remoteIP().toString() + " " + request->url();
-    Serial.println(logmessage);
+    systemPrintln(logmessage);
     request->send(200, "text/plain", getFileList());
   });
 
@@ -146,12 +146,12 @@ void startWebServer()
 
       if (sd->exists(fileName) == false)
       {
-        Serial.println(logmessage + " ERROR: file does not exist");
+        systemPrintln(logmessage + " ERROR: file does not exist");
         request->send(400, "text/plain", "ERROR: file does not exist");
       }
       else
       {
-        Serial.println(logmessage + " file exists");
+        systemPrintln(logmessage + " file exists");
 
         if (strcmp(fileAction, "download") == 0)
         {
@@ -162,7 +162,7 @@ void startWebServer()
             if (managerTempFile.open(fileName, O_READ) == true)
               managerFileOpen = true;
             else
-              Serial.println("Error: File Manager failed to open file");
+              systemPrintln("Error: File Manager failed to open file");
           }
           else
           {
@@ -191,7 +191,7 @@ void startWebServer()
 
               //xSemaphoreGive(sdCardSemaphore);
 
-              //Serial.println("Send me more");
+              //systemPrintln("Send me more");
               websocket->textAll("fmNext,1,"); //Tell browser to send next file if needed
             }
 
@@ -214,7 +214,7 @@ void startWebServer()
           logmessage += " ERROR: invalid action param supplied";
           request->send(400, "text/plain", "ERROR: invalid action param supplied");
         }
-        Serial.println(logmessage);
+        systemPrintln(logmessage);
       }
     }
     else
@@ -266,7 +266,7 @@ void stopWebServer()
 #ifdef COMPILE_AP
 void notFound(AsyncWebServerRequest *request) {
   String logmessage = "Client:" + request->client()->remoteIP().toString() + " " + request->url();
-  Serial.println(logmessage);
+  systemPrintln(logmessage);
   request->send(404, "text/plain", "Not found");
 }
 #endif
@@ -302,13 +302,13 @@ static void handleFirmwareFileUpload(AsyncWebServerRequest * request, String fil
       }
       else
       {
-        Serial.printf("Unknown: %s\r\n", fname);
+        systemPrintf("Unknown: %s\r\n", fname);
         return request->send(400, "text/html", "<b>Error:</b> Unknown file type");
       }
     }
     else
     {
-      Serial.printf("Unknown: %s\r\n", fname);
+      systemPrintf("Unknown: %s\r\n", fname);
       return request->send(400, "text/html", "<b>Error:</b> Unknown file type");
     }
   }
@@ -330,12 +330,12 @@ static void handleFirmwareFileUpload(AsyncWebServerRequest * request, String fil
         char bytesSentMsg[100];
         sprintf(bytesSentMsg, "%'d bytes sent", binBytesSent);
 
-        Serial.printf("bytesSentMsg: %s\r\n", bytesSentMsg);
+        systemPrintf("bytesSentMsg: %s\r\n", bytesSentMsg);
 
         char statusMsg[200] = {'\0'};
         stringRecord(statusMsg, "firmwareUploadStatus", bytesSentMsg); //Convert to "firmwareUploadMsg,11214 bytes sent,"
 
-        Serial.printf("msg: %s\r\n", statusMsg);
+        systemPrintf("msg: %s\r\n", statusMsg);
         websocket->textAll(statusMsg);
       }
 
@@ -352,7 +352,7 @@ static void handleFirmwareFileUpload(AsyncWebServerRequest * request, String fil
     else
     {
       websocket->textAll("firmwareUploadComplete,1,");
-      Serial.println("Firmware update complete. Restarting");
+      systemPrintln("Firmware update complete. Restarting");
       delay(500);
       ESP.restart();
     }
@@ -660,8 +660,8 @@ void createSettingsString(char* settingsCSV)
   //...
 
   strcat(settingsCSV, "\0");
-  Serial.printf("settingsCSV len: %d\r\n", strlen(settingsCSV));
-  Serial.printf("settingsCSV: %s\r\n", settingsCSV);
+  systemPrintf("settingsCSV len: %d\r\n", strlen(settingsCSV));
+  systemPrintf("settingsCSV: %s\r\n", settingsCSV);
 #endif
 }
 
@@ -875,7 +875,7 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
     websocket->textAll("confirmReset,1,");
     delay(500); //Allow for delivery
 
-    Serial.println("Reset after AP Config");
+    systemPrintln("Reset after AP Config");
 
     ESP.restart();
   }
@@ -967,7 +967,7 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
     //Last catch
     if (knownSetting == false)
     {
-      Serial.printf("Unknown '%s': %0.3lf\r\n", settingName, settingValue);
+      systemPrintf("Unknown '%s': %0.3lf\r\n", settingName, settingValue);
     }
   } //End last strcpy catch
 #endif
@@ -1114,14 +1114,14 @@ String getFileList()
 
     //This is an error because the current settings no longer match the settings
     //on the microSD card, and will not be restored to the expected settings!
-    Serial.printf("sdCardSemaphore failed to yield, held by %s, Form.ino line %d\r\n", semaphoreHolder, __LINE__);
+    systemPrintf("sdCardSemaphore failed to yield, held by %s, Form.ino line %d\r\n", semaphoreHolder, __LINE__);
   }
 
-  Serial.print("string size: ");
-  Serial.println(returnText.length());
+  //systemPrint("string size: ");
+  //systemPrintln(returnText.length());
 
-  Serial.print("returnText: ");
-  Serial.println(returnText);
+  //systemPrint("returnText: ");
+  //systemPrintln(returnText);
 
   return returnText;
 }
@@ -1169,7 +1169,7 @@ void handleUpload(AsyncWebServerRequest * request, String filename, size_t index
       xSemaphoreGive(sdCardSemaphore);
     }
 
-    Serial.println(logmessage);
+    systemPrintln(logmessage);
   }
 
   if (len)
@@ -1196,7 +1196,7 @@ void handleUpload(AsyncWebServerRequest * request, String filename, size_t index
       xSemaphoreGive(sdCardSemaphore);
     }
 
-    Serial.println(logmessage);
+    systemPrintln(logmessage);
     request->redirect("/");
   }
 }

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -37,7 +37,7 @@ void loadSettings()
   //Get bitmask of active profiles
   activeProfiles = loadProfileNames();
 
-  Serial.printf("Profile '%s' loaded\r\n", profileNames[profileNumber]);
+  systemPrintf("Profile '%s' loaded\r\n", profileNames[profileNumber]);
 }
 
 //Set the settingsFileName used many places
@@ -96,7 +96,7 @@ void recordSystemSettingsToFileSD(char *fileName)
       SdFile settingsFile; //FAT32
       if (settingsFile.open(fileName, O_CREAT | O_APPEND | O_WRITE) == false)
       {
-        Serial.println("Failed to create settings file");
+        systemPrintln("Failed to create settings file");
         break;
       }
 
@@ -117,7 +117,7 @@ void recordSystemSettingsToFileSD(char *fileName)
 
       //This is an error because the current settings no longer match the settings
       //on the microSD card, and will not be restored to the expected settings!
-      Serial.printf("sdCardSemaphore failed to yield, held by %s, NVM.ino line %d\r\n", semaphoreHolder, __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, held by %s, NVM.ino line %d\r\n", semaphoreHolder, __LINE__);
     }
     break;
   }
@@ -339,7 +339,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
         SdFile settingsFile; //FAT32
         if (settingsFile.open(fileName, O_READ) == false)
         {
-          Serial.println("Failed to open settings file");
+          systemPrintln("Failed to open settings file");
           break;
         }
 
@@ -352,23 +352,23 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
           //int n = getLine(&settingsFile, line, sizeof(line)); //Use with SD library
           int n = settingsFile.fgets(line, sizeof(line)); //Use with SdFat library
           if (n <= 0) {
-            Serial.printf("Failed to read line %d from settings file\r\n", lineNumber);
+            systemPrintf("Failed to read line %d from settings file\r\n", lineNumber);
           }
           else if (line[n - 1] != '\n' && n == (sizeof(line) - 1)) {
-            Serial.printf("Settings line %d too long\r\n", lineNumber);
+            systemPrintf("Settings line %d too long\r\n", lineNumber);
             if (lineNumber == 0)
             {
               //If we can't read the first line of the settings file, give up
-              Serial.println("Giving up on settings file");
+              systemPrintln("Giving up on settings file");
               break;
             }
           }
           else if (parseLine(line, settings) == false) {
-            Serial.printf("Failed to parse line %d: %s\r\n", lineNumber, line);
+            systemPrintf("Failed to parse line %d: %s\r\n", lineNumber, line);
             if (lineNumber == 0)
             {
               //If we can't read the first line of the settings file, give up
-              Serial.println("Giving up on settings file");
+              systemPrintln("Giving up on settings file");
               break;
             }
           }
@@ -376,7 +376,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
           lineNumber++;
         }
 
-        //Serial.println("Config file read complete");
+        //systemPrintln("Config file read complete");
         settingsFile.close();
         status = true;
         break;
@@ -391,7 +391,7 @@ bool loadSystemSettingsFromFileSD(char* fileName, Settings *settings)
     {
       //This is an error because if the settings exist on the microSD card that
       //those settings are not overriding the current settings as documented!
-      Serial.printf("sdCardSemaphore failed to yield, NVM.ino line %d\r\n", __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, NVM.ino line %d\r\n", __LINE__);
     }
     break;
   } //End SD online
@@ -426,23 +426,23 @@ bool loadSystemSettingsFromFileLFS(char* fileName, Settings *settings)
     int n = getLine(&settingsFile, line, sizeof(line)); //Use with SD library
     //int n = settingsFile.fgets(line, sizeof(line)); //Use with SdFat library
     if (n <= 0) {
-      Serial.printf("Failed to read line %d from settings file\r\n", lineNumber);
+      systemPrintf("Failed to read line %d from settings file\r\n", lineNumber);
     }
     else if (line[n - 1] != '\n' && n == (sizeof(line) - 1)) {
-      Serial.printf("Settings line %d too long\r\n", lineNumber);
+      systemPrintf("Settings line %d too long\r\n", lineNumber);
       if (lineNumber == 0)
       {
         //If we can't read the first line of the settings file, give up
-        Serial.println("Giving up on settings file");
+        systemPrintln("Giving up on settings file");
         return (false);
       }
     }
     else if (parseLine(line, settings) == false) {
-      Serial.printf("Failed to parse line %d: %s\r\n", lineNumber, line);
+      systemPrintf("Failed to parse line %d: %s\r\n", lineNumber, line);
       if (lineNumber == 0)
       {
         //If we can't read the first line of the settings file, give up
-        Serial.println("Giving up on settings file");
+        systemPrintln("Giving up on settings file");
         return (false);
       }
     }
@@ -487,7 +487,7 @@ bool parseLine(char* str, Settings *settings)
   {
     //if (strcmp(settingName, "ntripServer_CasterHost") == 0) //Debug
     //if (strcmp(settingName, "profileName") == 0) //Debug
-    //  Serial.printf("Found problem spot raw: %s\r\n", str);
+    //  systemPrintf("Found problem spot raw: %s\r\n", str);
 
     //Assume the value is a string such as 8d8a48b. The leading number causes skipSpace to fail.
     //If settingValue has a mix of letters and numbers, just convert to string
@@ -513,7 +513,7 @@ bool parseLine(char* str, Settings *settings)
       //It's a mix. Skip strtod.
 
       //if (strcmp(settingName, "ntripServer_CasterHost") == 0) //Debug
-      //  Serial.printf("Skipping strtod - settingValue: %s\r\n", settingValue);
+      //  systemPrintf("Skipping strtod - settingValue: %s\r\n", settingValue);
     }
     else
     {
@@ -548,7 +548,7 @@ bool parseLine(char* str, Settings *settings)
 
     //Check to see if this setting file is compatible with this version of RTK Surveyor
     if (d != sizeof(Settings))
-      Serial.printf("Warning: Settings size is %d but current firmware expects %d. Attempting to use settings from file.\r\n", (int)d, sizeof(Settings));
+      systemPrintf("Warning: Settings size is %d but current firmware expects %d. Attempting to use settings from file.\r\n", (int)d, sizeof(Settings));
 
   }
   else if (strcmp(settingName, "rtkIdentifier") == 0)
@@ -1009,7 +1009,7 @@ bool parseLine(char* str, Settings *settings)
     //Last catch
     if (knownSetting == false)
     {
-      Serial.printf("Unknown setting %s\r\n", settingName);
+      systemPrintf("Unknown setting %s\r\n", settingName);
     }
   }
 
@@ -1055,7 +1055,7 @@ void loadProfileNumber()
   File fileProfileNumber = LittleFS.open("/profileNumber.txt", FILE_READ);
   if (!fileProfileNumber)
   {
-    Serial.println("profileNumber.txt not found");
+    systemPrintln("profileNumber.txt not found");
     settings.updateZEDSettings = true; //Force module update
     recordProfileNumber(0); //Record profile
   }
@@ -1068,7 +1068,7 @@ void loadProfileNumber()
   //We have arbitrary limit of user profiles
   if (profileNumber >= MAX_PROFILE_COUNT)
   {
-    Serial.println("ProfileNumber invalid. Going to zero.");
+    systemPrintln("ProfileNumber invalid. Going to zero.");
     settings.updateZEDSettings = true; //Force module update
     recordProfileNumber(0); //Record profile
   }

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -97,14 +97,14 @@ bool ntripClientConnect()
       strcpy(settings.ntripClient_CasterHost, token);
   }
 
-  Serial.printf("NTRIP Client connecting to %s:%d\r\n", settings.ntripClient_CasterHost, settings.ntripClient_CasterPort);
+  systemPrintf("NTRIP Client connecting to %s:%d\r\n", settings.ntripClient_CasterHost, settings.ntripClient_CasterPort);
 
   int connectResponse = ntripClient->connect(settings.ntripClient_CasterHost, settings.ntripClient_CasterPort);
 
   if (connectResponse < 1)
     return false;
 
-  Serial.println("NTRIP Client connected");
+  systemPrintln("NTRIP Client connected");
 
   // Set up the server request (GET)
   char serverRequest[SERVER_BUFFER_SIZE];
@@ -125,8 +125,8 @@ bool ntripClientConnect()
     char userCredentials[sizeof(settings.ntripClient_CasterUser) + sizeof(settings.ntripClient_CasterUserPW) + 1]; //The ':' takes up a spot
     snprintf(userCredentials, sizeof(userCredentials), "%s:%s", settings.ntripClient_CasterUser, settings.ntripClient_CasterUserPW);
 
-    Serial.print("NTRIP Client sending credentials: ");
-    Serial.println(userCredentials);
+    systemPrint("NTRIP Client sending credentials: ");
+    systemPrintln(userCredentials);
 
     //Encode with ESP32 built-in library
     base64 b;
@@ -141,15 +141,15 @@ bool ntripClientConnect()
   strncat(serverRequest, credentials, SERVER_BUFFER_SIZE - 1);
   strncat(serverRequest, "\r\n", SERVER_BUFFER_SIZE - 1);
 
-  Serial.print("NTRIP Client serverRequest size: ");
-  Serial.print(strlen(serverRequest));
-  Serial.print(" of ");
-  Serial.print(sizeof(serverRequest));
-  Serial.println(" bytes available");
+  systemPrint("NTRIP Client serverRequest size: ");
+  systemPrint(strlen(serverRequest));
+  systemPrint(" of ");
+  systemPrint(sizeof(serverRequest));
+  systemPrintln(" bytes available");
 
   // Send the server request
-  Serial.println("NTRIP Client sending server request: ");
-  Serial.println(serverRequest);
+  systemPrintln("NTRIP Client sending server request: ");
+  systemPrintln(serverRequest);
   ntripClient->write(serverRequest, strlen(serverRequest));
   ntripClientTimer = millis();
   return true;
@@ -178,7 +178,7 @@ bool ntripClientConnectLimitReached()
   else
   {
     //No more connection attempts, switching to Bluetooth
-    Serial.println("NTRIP Client connection attempts exceeded!");
+    systemPrintln("NTRIP Client connection attempts exceeded!");
 
     //Stop WiFi operations
     ntripClientStop(true); //Do not allocate new wifiClient
@@ -212,30 +212,30 @@ void ntripClientResponse(char * response, size_t maxLength)
 void ntripClientSetState(byte newState)
 {
   if (ntripClientState == newState)
-    Serial.print("*");
+    systemPrint("*");
   ntripClientState = newState;
   switch (newState)
   {
     default:
-      Serial.printf("Unknown NTRIP Client state: %d\r\n", newState);
+      systemPrintf("Unknown NTRIP Client state: %d\r\n", newState);
       break;
     case NTRIP_CLIENT_OFF:
-      Serial.println("NTRIP_CLIENT_OFF");
+      systemPrintln("NTRIP_CLIENT_OFF");
       break;
     case NTRIP_CLIENT_ON:
-      Serial.println("NTRIP_CLIENT_ON");
+      systemPrintln("NTRIP_CLIENT_ON");
       break;
     case NTRIP_CLIENT_WIFI_CONNECTING:
-      Serial.println("NTRIP_CLIENT_WIFI_CONNECTING");
+      systemPrintln("NTRIP_CLIENT_WIFI_CONNECTING");
       break;
     case NTRIP_CLIENT_WIFI_CONNECTED:
-      Serial.println("NTRIP_CLIENT_WIFI_CONNECTED");
+      systemPrintln("NTRIP_CLIENT_WIFI_CONNECTED");
       break;
     case NTRIP_CLIENT_CONNECTING:
-      Serial.println("NTRIP_CLIENT_CONNECTING");
+      systemPrintln("NTRIP_CLIENT_CONNECTING");
       break;
     case NTRIP_CLIENT_CONNECTED:
-      Serial.println("NTRIP_CLIENT_CONNECTED");
+      systemPrintln("NTRIP_CLIENT_CONNECTED");
       break;
   }
 }
@@ -257,7 +257,7 @@ void ntripClientStart()
   {
     //Display the heap state
     reportHeapNow();
-    Serial.println("NTRIP Client start");
+    systemPrintln("NTRIP Client start");
 
     //Allocate the ntripClient structure
     ntripClient = new WiFiClient();
@@ -332,7 +332,7 @@ void ntripClientUpdate()
     case NTRIP_CLIENT_ON:
       if (strlen(settings.ntripClient_wifiSSID) == 0)
       {
-        Serial.println("Error: Please enter SSID before starting NTRIP Client");
+        systemPrintln("Error: Please enter SSID before starting NTRIP Client");
         ntripClientSetState(NTRIP_CLIENT_OFF);
       }
       else
@@ -349,7 +349,7 @@ void ntripClientUpdate()
           if (millis() - ntripClientTimeoutPrint > 1000)
           {
             ntripClientTimeoutPrint = millis();
-            Serial.printf("NTRIP Client connection timeout wait: %ld of %d seconds \r\n",
+            systemPrintf("NTRIP Client connection timeout wait: %ld of %d seconds \r\n",
                           (millis() - ntripClientLastConnectionAttempt) / 1000,
                           ntripClientConnectionAttemptTimeout / 1000
                          );
@@ -366,7 +366,7 @@ void ntripClientUpdate()
         if (wifiConnectionTimeout() || wifiGetStatus() == WL_NO_SSID_AVAIL)
         {
           if (wifiGetStatus() == WL_NO_SSID_AVAIL)
-            Serial.printf("WiFi network '%s' not found\r\n", settings.ntripClient_wifiSSID);
+            systemPrintf("WiFi network '%s' not found\r\n", settings.ntripClient_wifiSSID);
 
           if (ntripClientConnectLimitReached()) //Stop WiFi, give up
             paintNtripWiFiFail(4000, true);
@@ -393,7 +393,7 @@ void ntripClientUpdate()
 
             //Assume service not available
             if (ntripClientConnectLimitReached())
-              Serial.println("NTRIP Client caster failed to connect. Do you have your caster address and port correct?");
+              systemPrintln("NTRIP Client caster failed to connect. Do you have your caster address and port correct?");
           }
           else
             //Socket opened to NTRIP system
@@ -415,7 +415,7 @@ void ntripClientUpdate()
         {
           //NTRIP web service did not respone
           if (ntripClientConnectLimitReached())
-            Serial.println("NTRIP Client caster failed to respond. Do you have your caster address and port correct?");
+            systemPrintln("NTRIP Client caster failed to respond. Do you have your caster address and port correct?");
         }
       }
       else
@@ -430,7 +430,7 @@ void ntripClientUpdate()
         if (strstr(response, "401") != NULL)
         {
           //Look for '401 Unauthorized'
-          Serial.printf("NTRIP Caster responded with bad news: %s. Are you sure your caster credentials are correct?\r\n", response);
+          systemPrintf("NTRIP Caster responded with bad news: %s. Are you sure your caster credentials are correct?\r\n", response);
 
           //Stop WiFi operations
           ntripClientStop(true); //Do not allocate new wifiClient
@@ -438,7 +438,7 @@ void ntripClientUpdate()
         else if (strstr(response, "banned") != NULL)
         {
           //Look for 'HTTP/1.1 200 OK' and banned IP information
-          Serial.printf("NTRIP Client connected to caster but caster reponded with problem: %s", response);
+          systemPrintf("NTRIP Client connected to caster but caster reponded with problem: %s", response);
 
           //Stop WiFi operations
           ntripClientStop(true); //Do not allocate new wifiClient
@@ -478,7 +478,7 @@ void ntripClientUpdate()
       if (!ntripClient->connected())
       {
         //Broken connection, retry the NTRIP client connection
-        Serial.println("NTRIP Client connection dropped");
+        systemPrintln("NTRIP Client connection dropped");
         ntripClientStop(false); //Allocate new wifiClient
       }
       else
@@ -489,7 +489,7 @@ void ntripClientUpdate()
           if ((millis() - ntripClientTimer) > NTRIP_CLIENT_RECEIVE_DATA_TIMEOUT)
           {
             //Timeout receiving NTRIP data, retry the NTRIP client connection
-            Serial.println("NTRIP Client: No data received timeout");
+            systemPrintln("NTRIP Client: No data received timeout");
             ntripClientStop(false); //Allocate new wifiClient
           }
         }

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -96,7 +96,7 @@ bool ntripServerConnectCaster()
       strcpy(settings.ntripServer_CasterHost, token);
   }
 
-  Serial.printf("NTRIP Server connecting to %s:%d\r\n", settings.ntripServer_CasterHost,
+  systemPrintf("NTRIP Server connecting to %s:%d\r\n", settings.ntripServer_CasterHost,
                 settings.ntripServer_CasterPort);
 
   //Attempt a connection to the NTRIP caster
@@ -104,7 +104,7 @@ bool ntripServerConnectCaster()
                             settings.ntripServer_CasterPort))
     return false;
 
-  Serial.println("NTRIP Server connected");
+  systemPrintln("NTRIP Server connected");
 
   //Build the authorization credentials message
   //  * Mount point
@@ -146,7 +146,7 @@ bool ntripServerConnectLimitReached()
   else
   {
     //No more connection attempts
-    Serial.println("NTRIP Server connection attempts exceeded!");
+    systemPrintln("NTRIP Server connection attempts exceeded!");
     ntripServerStop(true);  //Don't allocate new wifiClient
   }
   return limitReached;
@@ -172,36 +172,36 @@ void ntripServerResponse(char * response, size_t maxLength)
 void ntripServerSetState(byte newState)
 {
   if (ntripServerState == newState)
-    Serial.print("*");
+    systemPrint("*");
   ntripServerState = newState;
   switch (newState)
   {
     default:
-      Serial.printf("Unknown NTRIP Server state: %d\r\n", newState);
+      systemPrintf("Unknown NTRIP Server state: %d\r\n", newState);
       break;
     case NTRIP_SERVER_OFF:
-      Serial.println("NTRIP_SERVER_OFF");
+      systemPrintln("NTRIP_SERVER_OFF");
       break;
     case NTRIP_SERVER_ON:
-      Serial.println("NTRIP_SERVER_ON");
+      systemPrintln("NTRIP_SERVER_ON");
       break;
     case NTRIP_SERVER_WIFI_CONNECTING:
-      Serial.println("NTRIP_SERVER_WIFI_CONNECTING");
+      systemPrintln("NTRIP_SERVER_WIFI_CONNECTING");
       break;
     case NTRIP_SERVER_WIFI_CONNECTED:
-      Serial.println("NTRIP_SERVER_WIFI_CONNECTED");
+      systemPrintln("NTRIP_SERVER_WIFI_CONNECTED");
       break;
     case NTRIP_SERVER_WAIT_GNSS_DATA:
-      Serial.println("NTRIP_SERVER_WAIT_GNSS_DATA");
+      systemPrintln("NTRIP_SERVER_WAIT_GNSS_DATA");
       break;
     case NTRIP_SERVER_CONNECTING:
-      Serial.println("NTRIP_SERVER_CONNECTING");
+      systemPrintln("NTRIP_SERVER_CONNECTING");
       break;
     case NTRIP_SERVER_AUTHORIZATION:
-      Serial.println("NTRIP_SERVER_AUTHORIZATION");
+      systemPrintln("NTRIP_SERVER_AUTHORIZATION");
       break;
     case NTRIP_SERVER_CASTING:
-      Serial.println("NTRIP_SERVER_CASTING");
+      systemPrintln("NTRIP_SERVER_CASTING");
       break;
   }
 }
@@ -237,7 +237,7 @@ void ntripServerProcessRTCM(uint8_t incoming)
         struct tm timeinfo = rtc.getTimeStruct();
         char timestamp[30];
         strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", &timeinfo);
-        Serial.printf("    Tx RTCM: %s.%03ld\r\n", timestamp, rtc.getMillis());
+        systemPrintf("    Tx RTCM: %s.%03ld\r\n", timestamp, rtc.getMillis());
       }
       previousMilliseconds = currentMilliseconds;
     }
@@ -353,7 +353,7 @@ void ntripServerUpdate()
     case NTRIP_SERVER_ON:
       if (strlen(settings.ntripServer_wifiSSID) == 0)
       {
-        Serial.println("Error: Please enter SSID before starting NTRIP Server");
+        systemPrintln("Error: Please enter SSID before starting NTRIP Server");
         ntripServerSetState(NTRIP_SERVER_OFF);
       }
       else
@@ -370,7 +370,7 @@ void ntripServerUpdate()
           if (millis() - ntripServerTimeoutPrint > 1000)
           {
             ntripServerTimeoutPrint = millis();
-            Serial.printf("NTRIP Server connection timeout wait: %ld of %d seconds \r\n",
+            systemPrintf("NTRIP Server connection timeout wait: %ld of %d seconds \r\n",
                           (millis() - ntripServerLastConnectionAttempt) / 1000,
                           ntripServerConnectionAttemptTimeout / 1000
                          );
@@ -387,11 +387,11 @@ void ntripServerUpdate()
         if (wifiConnectionTimeout() || wifiGetStatus() == WL_NO_SSID_AVAIL)
         {
           if (wifiGetStatus() == WL_NO_SSID_AVAIL)
-            Serial.printf("WiFi network '%s' not found\r\n", settings.ntripServer_wifiSSID);
+            systemPrintf("WiFi network '%s' not found\r\n", settings.ntripServer_wifiSSID);
 
           if (ntripServerConnectLimitReached())
           {
-            Serial.println("NTRIP Server failed to get WiFi. Are your WiFi credentials correct?");
+            systemPrintln("NTRIP Server failed to get WiFi. Are your WiFi credentials correct?");
 
             //Display the WiFi failure
             paintNtripWiFiFail(4000, false);
@@ -436,7 +436,7 @@ void ntripServerUpdate()
         //Assume service not available
         if (ntripServerConnectLimitReached())
         {
-          Serial.println("NTRIP Server failed to connect! Do you have your caster address and port correct?");
+          systemPrintln("NTRIP Server failed to connect! Do you have your caster address and port correct?");
         }
       }
       else
@@ -455,11 +455,11 @@ void ntripServerUpdate()
         //Check for response timeout
         if (millis() - ntripServerTimer > 10000)
         {
-          Serial.println("Caster failed to respond in time.");
+          systemPrintln("Caster failed to respond in time.");
 
           if (ntripServerConnectLimitReached())
           {
-            Serial.println("Caster failed to respond. Do you have your caster address and port correct?");
+            systemPrintln("Caster failed to respond. Do you have your caster address and port correct?");
           }
         }
       }
@@ -473,7 +473,7 @@ void ntripServerUpdate()
         if (strstr(response, "401") != NULL)
         {
           //Look for '401 Unauthorized'
-          Serial.printf("NTRIP Caster responded with bad news: %s. Are you sure your caster credentials are correct?\r\n", response);
+          systemPrintf("NTRIP Caster responded with bad news: %s. Are you sure your caster credentials are correct?\r\n", response);
 
           //Give up - Stop WiFi operations
           ntripServerStop(true); //Do not allocate new wifiClient
@@ -481,7 +481,7 @@ void ntripServerUpdate()
         else if (strstr(response, "banned") != NULL) //'Banned' found
         {
           //Look for 'HTTP/1.1 200 OK' and banned IP information
-          Serial.printf("NTRIP Server connected to caster but caster reponded with problem: %s", response);
+          systemPrintf("NTRIP Server connected to caster but caster reponded with problem: %s", response);
 
           //Give up - Stop WiFi operations
           ntripServerStop(true); //Do not allocate new wifiClient
@@ -489,18 +489,18 @@ void ntripServerUpdate()
         else if (strstr(response, "200") == NULL) //'200' not found
         {
           //Look for 'ERROR - Mountpoint taken' from Emlid.
-          Serial.printf("NTRIP Server connected but caster reponded with problem: %s", response);
+          systemPrintf("NTRIP Server connected but caster reponded with problem: %s", response);
 
           //Attempt to reconnect after throttle controlled timeout
           if (ntripServerConnectLimitReached())
           {
-            Serial.println("Caster failed to respond. Do you have your caster address and port correct?");
+            systemPrintln("Caster failed to respond. Do you have your caster address and port correct?");
           }
         }        
         else if (strstr(response, "200") != NULL) //'200' found
 
         {
-          Serial.printf("NTRIP Server connected to %s:%d %s\r\n",
+          systemPrintf("NTRIP Server connected to %s:%d %s\r\n",
                         settings.ntripServer_CasterHost,
                         settings.ntripServer_CasterPort,
                         settings.ntripServer_MountPoint);
@@ -522,13 +522,13 @@ void ntripServerUpdate()
       if (!ntripServer->connected())
       {
         //Broken connection, retry the NTRIP connection
-        Serial.println("Connection to NTRIP Caster was lost");
+        systemPrintln("Connection to NTRIP Caster was lost");
         ntripServerStop(false); //Allocate new wifiClient
       }
       else if ((millis() - ntripServerTimer) > (3 * 1000))
       {
         //GNSS stopped sending RTCM correction data
-        Serial.println("NTRIP Server breaking connection to caster due to lack of RTCM data!");
+        systemPrintln("NTRIP Server breaking connection to caster due to lack of RTCM data!");
         ntripServerStop(false); //Allocate new wifiClient
       }
       else

--- a/Firmware/RTK_Surveyor/Rover.ino
+++ b/Firmware/RTK_Surveyor/Rover.ino
@@ -86,9 +86,9 @@ void updateAccuracyLEDs()
       {
         if (settings.enablePrintRoverAccuracy)
         {
-          Serial.print("Rover Accuracy (m): ");
-          Serial.print(horizontalAccuracy, 4); // Print the accuracy with 4 decimal places
-          Serial.println();
+          systemPrint("Rover Accuracy (m): ");
+          systemPrint(horizontalAccuracy, 4); // Print the accuracy with 4 decimal places
+          systemPrintln();
         }
 
         if (productVariant == RTK_SURVEYOR)
@@ -121,12 +121,12 @@ void updateAccuracyLEDs()
       }
       else if (settings.enablePrintRoverAccuracy)
       {
-        Serial.print("Rover Accuracy: ");
-        Serial.print(horizontalAccuracy);
-        Serial.print(" ");
-        Serial.print("No lock. SIV: ");
-        Serial.print(numSV);
-        Serial.println();
+        systemPrint("Rover Accuracy: ");
+        systemPrint(horizontalAccuracy);
+        systemPrint(" ");
+        systemPrint("No lock. SIV: ");
+        systemPrint(numSV);
+        systemPrintln();
       }
     } //End GNSS online checking
   } //Check every 2000ms

--- a/Firmware/RTK_Surveyor/States.ino
+++ b/Firmware/RTK_Surveyor/States.ino
@@ -107,7 +107,7 @@ void updateSystemState()
           //If we are survey'd in, but switch is rover then disable survey
           if (configureUbloxModuleRover() == false)
           {
-            Serial.println("Rover config failed");
+            systemPrintln("Rover config failed");
             displayRoverFail(1000);
             return;
           }
@@ -274,7 +274,7 @@ void updateSystemState()
           }
 
           //Check for <1m horz accuracy before starting surveyIn
-          Serial.printf("Waiting for Horz Accuracy < %0.2f meters: %0.2f\r\n", settings.surveyInStartingAccuracy, horizontalAccuracy);
+          systemPrintf("Waiting for Horz Accuracy < %0.2f meters: %0.2f\r\n", settings.surveyInStartingAccuracy, horizontalAccuracy);
 
           if (horizontalAccuracy > 0.0 && horizontalAccuracy < settings.surveyInStartingAccuracy)
           {
@@ -308,8 +308,8 @@ void updateSystemState()
 
           if (i2cGNSS.getSurveyInValid(50) == true) //Survey in complete
           {
-            Serial.printf("Observation Time: %d\r\n", svinObservationTime);
-            Serial.println("Base survey complete! RTCM now broadcasting.");
+            systemPrintf("Observation Time: %d\r\n", svinObservationTime);
+            systemPrintln("Base survey complete! RTCM now broadcasting.");
 
             if (productVariant == RTK_SURVEYOR)
               digitalWrite(pin_baseStatusLED, HIGH); //Indicate survey complete
@@ -325,17 +325,17 @@ void updateSystemState()
           }
           else
           {
-            Serial.print("Time elapsed: ");
-            Serial.print(svinObservationTime);
-            Serial.print(" Accuracy: ");
-            Serial.print(svinMeanAccuracy);
-            Serial.print(" SIV: ");
-            Serial.print(numSV);
-            Serial.println();
+            systemPrint("Time elapsed: ");
+            systemPrint(svinObservationTime);
+            systemPrint(" Accuracy: ");
+            systemPrint(svinMeanAccuracy);
+            systemPrint(" SIV: ");
+            systemPrint(numSV);
+            systemPrintln();
 
             if (svinObservationTime > maxSurveyInWait_s)
             {
-              Serial.printf("Survey-In took more than %d minutes. Returning to rover mode.\r\n", maxSurveyInWait_s / 60);
+              systemPrintf("Survey-In took more than %d minutes. Returning to rover mode.\r\n", maxSurveyInWait_s / 60);
 
               surveyInReset();
 
@@ -389,7 +389,7 @@ void updateSystemState()
           }
           else
           {
-            Serial.println("Fixed base start failed");
+            systemPrintln("Fixed base start failed");
             displayBaseFail(1000);
 
             changeState(STATE_ROVER_NOT_STARTED); //Return to rover mode to avoid being in fixed base mode
@@ -611,10 +611,10 @@ void updateSystemState()
             //Allow for 750ms before we parse buffer for all data to arrive
             if (millis() - timeSinceLastIncomingSetting > 750)
             {
-              Serial.print("Parsing: ");
+              systemPrint("Parsing: ");
               for (int x = 0 ; x < incomingSettingsSpot ; x++)
                 Serial.write(incomingSettings[x]);
-              Serial.println();
+              systemPrintln();
 
               parseIncomingSettings();
               settings.updateZEDSettings = true; //When this profile is loaded next, force system to update ZED settings.
@@ -764,7 +764,7 @@ void updateSystemState()
           }
           else
           {
-            Serial.print(".");
+            systemPrint(".");
             if (wifiConnectionTimeout())
             {
               //Give up after connection timeout
@@ -796,7 +796,7 @@ void updateSystemState()
             if (settings.pointPerfectNextKeyStart > 0)
             {
               uint8_t daysRemaining = daysFromEpoch(settings.pointPerfectNextKeyStart + settings.pointPerfectNextKeyDuration + 1);
-              Serial.printf("Days until PointPerfect keys expire: %d\r\n", daysRemaining);
+              systemPrintf("Days until PointPerfect keys expire: %d\r\n", daysRemaining);
               paintKeyDaysRemaining(daysRemaining, 2000);
             }
           }
@@ -875,7 +875,7 @@ void updateSystemState()
           }
           else
           {
-            Serial.print(".");
+            systemPrint(".");
             if (wifiConnectionTimeout())
             {
               //Give up after connection timeout
@@ -960,7 +960,7 @@ void updateSystemState()
 
       default:
         {
-          Serial.printf("Unknown state: %d\r\n", systemState);
+          systemPrintf("Unknown state: %d\r\n", systemState);
         }
         break;
     }
@@ -988,7 +988,7 @@ void changeState(SystemState newState)
     return;
 
   if (settings.enablePrintStates && (newState == systemState))
-    Serial.print("*");
+    systemPrint("*");
 
   //Set the new state
   systemState = newState;
@@ -998,113 +998,113 @@ void changeState(SystemState newState)
     switch (systemState)
     {
       case (STATE_ROVER_NOT_STARTED):
-        Serial.print("State: Rover - Not Started");
+        systemPrint("State: Rover - Not Started");
         break;
       case (STATE_ROVER_NO_FIX):
-        Serial.print("State: Rover - No Fix");
+        systemPrint("State: Rover - No Fix");
         break;
       case (STATE_ROVER_FIX):
-        Serial.print("State: Rover - Fix");
+        systemPrint("State: Rover - Fix");
         break;
       case (STATE_ROVER_RTK_FLOAT):
-        Serial.print("State: Rover - RTK Float");
+        systemPrint("State: Rover - RTK Float");
         break;
       case (STATE_ROVER_RTK_FIX):
-        Serial.print("State: Rover - RTK Fix");
+        systemPrint("State: Rover - RTK Fix");
         break;
       case (STATE_BASE_NOT_STARTED):
-        Serial.print("State: Base - Not Started");
+        systemPrint("State: Base - Not Started");
         break;
       case (STATE_BASE_TEMP_SETTLE):
-        Serial.print("State: Base-Temp - Settle");
+        systemPrint("State: Base-Temp - Settle");
         break;
       case (STATE_BASE_TEMP_SURVEY_STARTED):
-        Serial.print("State: Base-Temp - Survey Started");
+        systemPrint("State: Base-Temp - Survey Started");
         break;
       case (STATE_BASE_TEMP_TRANSMITTING):
-        Serial.print("State: Base-Temp - Transmitting");
+        systemPrint("State: Base-Temp - Transmitting");
         break;
       case (STATE_BASE_FIXED_NOT_STARTED):
-        Serial.print("State: Base-Fixed - Not Started");
+        systemPrint("State: Base-Fixed - Not Started");
         break;
       case (STATE_BASE_FIXED_TRANSMITTING):
-        Serial.print("State: Base-Fixed - Transmitting");
+        systemPrint("State: Base-Fixed - Transmitting");
         break;
       case (STATE_BUBBLE_LEVEL):
-        Serial.print("State: Bubble level");
+        systemPrint("State: Bubble level");
         break;
       case (STATE_MARK_EVENT):
-        Serial.print("State: Mark Event");
+        systemPrint("State: Mark Event");
         break;
       case (STATE_DISPLAY_SETUP):
-        Serial.print("State: Display Setup");
+        systemPrint("State: Display Setup");
         break;
       case (STATE_WIFI_CONFIG_NOT_STARTED):
-        Serial.print("State: WiFi Config Not Started");
+        systemPrint("State: WiFi Config Not Started");
         break;
       case (STATE_WIFI_CONFIG):
-        Serial.print("State: WiFi Config");
+        systemPrint("State: WiFi Config");
         break;
       case (STATE_TEST):
-        Serial.print("State: System Test Setup");
+        systemPrint("State: System Test Setup");
         break;
       case (STATE_TESTING):
-        Serial.print("State: System Testing");
+        systemPrint("State: System Testing");
         break;
       case (STATE_PROFILE):
-        Serial.print("State: Profile");
+        systemPrint("State: Profile");
         break;
 #ifdef COMPILE_L_BAND
       case (STATE_KEYS_STARTED):
-        Serial.print("State: Keys Started ");
+        systemPrint("State: Keys Started ");
         break;
       case (STATE_KEYS_NEEDED):
-        Serial.print("State: Keys Needed");
+        systemPrint("State: Keys Needed");
         break;
       case (STATE_KEYS_WIFI_STARTED):
-        Serial.print("State: Keys WiFi Started");
+        systemPrint("State: Keys WiFi Started");
         break;
       case (STATE_KEYS_WIFI_CONNECTED):
-        Serial.print("State: Keys WiFi Connected");
+        systemPrint("State: Keys WiFi Connected");
         break;
       case (STATE_KEYS_WIFI_TIMEOUT):
-        Serial.print("State: Keys WiFi Timeout");
+        systemPrint("State: Keys WiFi Timeout");
         break;
       case (STATE_KEYS_EXPIRED):
-        Serial.print("State: Keys Expired");
+        systemPrint("State: Keys Expired");
         break;
       case (STATE_KEYS_DAYS_REMAINING):
-        Serial.print("State: Keys Days Remaining");
+        systemPrint("State: Keys Days Remaining");
         break;
       case (STATE_KEYS_LBAND_CONFIGURE):
-        Serial.print("State: Keys L-Band Configure");
+        systemPrint("State: Keys L-Band Configure");
         break;
       case (STATE_KEYS_LBAND_ENCRYPTED):
-        Serial.print("State: Keys L-Band Encrypted");
+        systemPrint("State: Keys L-Band Encrypted");
         break;
       case (STATE_KEYS_PROVISION_WIFI_STARTED):
-        Serial.print("State: Keys Provision - WiFi Started");
+        systemPrint("State: Keys Provision - WiFi Started");
         break;
       case (STATE_KEYS_PROVISION_WIFI_CONNECTED):
-        Serial.print("State: Keys Provision - WiFi Connected");
+        systemPrint("State: Keys Provision - WiFi Connected");
         break;
       case (STATE_KEYS_PROVISION_WIFI_TIMEOUT):
-        Serial.print("State: Keys Provision - WiFi Timeout");
+        systemPrint("State: Keys Provision - WiFi Timeout");
         break;
 #endif  //COMPILE_L_BAND
 
       case (STATE_ESPNOW_PAIRING_NOT_STARTED):
-        Serial.print("State: ESP-Now Pairing Not Started");
+        systemPrint("State: ESP-Now Pairing Not Started");
         break;
       case (STATE_ESPNOW_PAIRING):
-        Serial.print("State: ESP-Now Pairing");
+        systemPrint("State: ESP-Now Pairing");
         break;
 
       case (STATE_SHUTDOWN):
-        Serial.print("State: Shut Down");
+        systemPrint("State: Shut Down");
         break;
       default:
-        Serial.printf("Change State Unknown: %d", systemState);
+        systemPrintf("Change State Unknown: %d", systemState);
         break;
     }
 
@@ -1117,9 +1117,9 @@ void changeState(SystemState newState)
       struct tm timeinfo = rtc.getTimeStruct();
       char s[30];
       strftime(s, sizeof(s), "%Y-%m-%d %H:%M:%S", &timeinfo);
-      Serial.printf(", %s.%03ld", s, rtc.getMillis());
+      systemPrintf(", %s.%03ld", s, rtc.getMillis());
     }
 
-    Serial.println();
+    systemPrintln();
   }
 }

--- a/Firmware/RTK_Surveyor/System.ino
+++ b/Firmware/RTK_Surveyor/System.ino
@@ -101,19 +101,19 @@ bool configureUbloxModule()
   response &= i2cGNSS.sendCfgValset();
 
   if (response == false)
-    Serial.println("Module failed config block 0");
+    systemPrintln("Module failed config block 0");
   response = true; //Reset
 
   //Enable the constellations the user has set
   response &= setConstellations(true); //19 messages. Send newCfg or sendCfg with value set
   if (response == false)
-    Serial.println("Module failed config block 1");
+    systemPrintln("Module failed config block 1");
   response = true; //Reset
 
   //Make sure the appropriate messages are enabled
   response &= setMessages(); //73 messages. Does a complete open/closed val set
   if (response == false)
-    Serial.println("Module failed config block 2");
+    systemPrintln("Module failed config block 2");
   response = true; //Reset
 
   //Disable NMEA messages on all but UART1
@@ -144,7 +144,7 @@ bool configureUbloxModule()
   response &= i2cGNSS.sendCfgValset();
 
   if (response == false)
-    Serial.println("Module failed config block 3");
+    systemPrintln("Module failed config block 3");
 
   if (zedModuleType == PLATFORM_F9R)
     response &= i2cGNSS.setAutoESFSTATUS(true, false); //Tell the GPS to "send" each ESF Status, but do not update stale data when accessed
@@ -235,14 +235,14 @@ void checkBatteryLevels()
 
   if (settings.enablePrintBatteryMessages)
   {
-    Serial.printf("Batt (%d%%): Voltage: %0.02fV", battLevel, battVoltage);
+    systemPrintf("Batt (%d%%): Voltage: %0.02fV", battLevel, battVoltage);
 
     char tempStr[25];
     if (battChangeRate > 0)
       sprintf(tempStr, "C");
     else
       sprintf(tempStr, "Disc");
-    Serial.printf(" %sharging: %0.02f%%/hr ", tempStr, battChangeRate);
+    systemPrintf(" %sharging: %0.02f%%/hr ", tempStr, battChangeRate);
 
     if (battLevel < 10)
       sprintf(tempStr, "Red");
@@ -253,7 +253,7 @@ void checkBatteryLevels()
     else
       sprintf(tempStr, "No batt");
 
-    Serial.printf("%s\r\n", tempStr);
+    systemPrintf("%s\r\n", tempStr);
   }
 
   if (productVariant == RTK_SURVEYOR)
@@ -313,7 +313,7 @@ void reportHeapNow()
   if (settings.enableHeapReport == true)
   {
     lastHeapReport = millis();
-    Serial.printf("FreeHeap: %d / HeapLowestPoint: %d / LargestBlock: %d\r\n", ESP.getFreeHeap(), xPortGetMinimumEverFreeHeapSize(), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    systemPrintf("FreeHeap: %d / HeapLowestPoint: %d / LargestBlock: %d\r\n", ESP.getFreeHeap(), xPortGetMinimumEverFreeHeapSize(), heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
   }
 }
 

--- a/Firmware/RTK_Surveyor/WiFi.ino
+++ b/Firmware/RTK_Surveyor/WiFi.ino
@@ -77,9 +77,9 @@ static WiFiClient wifiTcpClient[WIFI_MAX_TCP_CLIENTS];
 
 void wifiDisplayIpAddress()
 {
-  Serial.print("WiFi IP address: ");
-  Serial.print(WiFi.localIP());
-  Serial.printf(" RSSI: %d\r\n", WiFi.RSSI());
+  systemPrint("WiFi IP address: ");
+  systemPrint(WiFi.localIP());
+  systemPrintf(" RSSI: %d\r\n", WiFi.RSSI());
 
   wifiTimer = millis();
 }
@@ -118,24 +118,24 @@ void wifiPeriodicallyDisplayIpAddress()
 void wifiSetState(byte newState)
 {
   if (wifiState == newState)
-    Serial.print("*");
+    systemPrint("*");
   wifiState = newState;
   switch (newState)
   {
     default:
-      Serial.printf("Unknown WiFi state: %d\r\n", newState);
+      systemPrintf("Unknown WiFi state: %d\r\n", newState);
       break;
     case WIFI_OFF:
-      Serial.println("WIFI_OFF");
+      systemPrintln("WIFI_OFF");
       break;
     case WIFI_ON:
-      Serial.println("WIFI_ON");
+      systemPrintln("WIFI_ON");
       break;
     case WIFI_NOTCONNECTED:
-      Serial.println("WIFI_NOTCONNECTED");
+      systemPrintln("WIFI_NOTCONNECTED");
       break;
     case WIFI_CONNECTED:
-      Serial.println("WIFI_CONNECTED");
+      systemPrintln("WIFI_CONNECTED");
       break;
   }
 }
@@ -161,14 +161,14 @@ void wifiStartAP()
 #endif
 
   WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-  Serial.print("WiFi connecting to");
+  systemPrint("WiFi connecting to");
   while (wifiGetStatus() != WL_CONNECTED)
   {
-    Serial.print(".");
+    systemPrint(".");
     delay(500);
   }
-  Serial.print("WiFi connected with IP: ");
-  Serial.println(WiFi.localIP());
+  systemPrint("WiFi connected with IP: ");
+  systemPrintln(WiFi.localIP());
 #else   //End LOCAL_WIFI_TESTING
   //Start in AP mode
 
@@ -186,11 +186,11 @@ void wifiStartAP()
   WiFi.softAPConfig(local_IP, gateway, subnet);
   if (WiFi.softAP("RTK Config") == false) //Must be short enough to fit OLED Width
   {
-    Serial.println("WiFi AP failed to start");
+    systemPrintln("WiFi AP failed to start");
     return;
   }
-  Serial.print("WiFi AP Started with IP: ");
-  Serial.println(WiFi.softAPIP());
+  systemPrint("WiFi AP Started with IP: ");
+  systemPrintln(WiFi.softAPIP());
 #endif  //End AP Testing
 }
 
@@ -206,7 +206,7 @@ bool wifiConnectionTimeout()
 #ifdef COMPILE_WIFI
   if ((millis() - wifiTimer) <= WIFI_CONNECTION_TIMEOUT)
     return false;
-  Serial.println("WiFi connection timeout!");
+  systemPrintln("WiFi connection timeout!");
 #endif  //COMPILE_WIFI
   return true;
 }
@@ -229,14 +229,14 @@ void wifiSendTcpData(uint8_t * data, uint16_t length)
       ipAddress[0] = WiFi.gatewayIP();
       if (settings.enablePrintTcpStatus)
       {
-        Serial.print("Trying to connect TCP client to ");
-        Serial.println(ipAddress[0]);
+        systemPrint("Trying to connect TCP client to ");
+        systemPrintln(ipAddress[0]);
       }
       if (wifiTcpClient[0].connect(ipAddress[0], WIFI_TCP_PORT))
       {
         online.tcpClient = true;
-        Serial.print("TCP client connected to ");
-        Serial.println(ipAddress[0]);
+        systemPrint("TCP client connected to ");
+        systemPrintln(ipAddress[0]);
         wifiTcpConnected |= 1 << index;
       }
       else
@@ -260,8 +260,8 @@ void wifiSendTcpData(uint8_t * data, uint16_t length)
           if (!wifiTcpClient[index])
             break;
           ipAddress[index] = wifiTcpClient[index].remoteIP();
-          Serial.printf("Connected TCP client %d to ", index);
-          Serial.println(ipAddress[index]);
+          systemPrintf("Connected TCP client %d to ", index);
+          systemPrintln(ipAddress[index]);
           wifiTcpConnected |= 1 << index;
         }
       }
@@ -274,7 +274,7 @@ void wifiSendTcpData(uint8_t * data, uint16_t length)
     {
       //Check for a broken connection
       if ((!wifiTcpClient[index]) || (!wifiTcpClient[index].connected()))
-        Serial.printf("Disconnected TCP client %d from ", index);
+        systemPrintf("Disconnected TCP client %d from ", index);
 
       //Send the data to the connected clients
       else if (((settings.enableTcpServer && online.tcpServer)
@@ -282,16 +282,16 @@ void wifiSendTcpData(uint8_t * data, uint16_t length)
                && ((!length) || (wifiTcpClient[index].write(data, length) == length)))
       {
         if (settings.enablePrintTcpStatus && length)
-          Serial.printf("%d bytes written over TCP\r\n", length);
+          systemPrintf("%d bytes written over TCP\r\n", length);
         continue;
       }
 
       //Failed to write the data
       else
-        Serial.printf("Breaking TCP client %d connection to ", index);
+        systemPrintf("Breaking TCP client %d connection to ", index);
 
       //Done with this client connection
-      Serial.println(ipAddress[index]);
+      systemPrintln(ipAddress[index]);
       wifiTcpClient[index].stop();
       wifiTcpConnected &= ~(1 << index);
 
@@ -350,7 +350,7 @@ void wifiStart(char* ssid, char* pw)
     esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N); //Set basic WiFi protocols. Stops WiFi Station.
 #endif
 
-    Serial.printf("WiFi connecting to %s\r\n", ssid);
+    systemPrintf("WiFi connecting to %s\r\n", ssid);
     WiFi.begin(ssid, pw);
     wifiTimer = millis();
 
@@ -362,7 +362,7 @@ void wifiStart(char* ssid, char* pw)
     //Verify WIFI_MAX_TCP_CLIENTS
     if ((sizeof(wifiTcpConnected) * 8) < WIFI_MAX_TCP_CLIENTS)
     {
-      Serial.printf("Please set WIFI_MAX_TCP_CLIENTS <= %d or increase size of wifiTcpConnected\r\n", sizeof(wifiTcpConnected) * 8);
+      systemPrintf("Please set WIFI_MAX_TCP_CLIENTS <= %d or increase size of wifiTcpConnected\r\n", sizeof(wifiTcpConnected) * 8);
       while (true)
       {
       }
@@ -388,7 +388,7 @@ void wifiStop()
     //Tell the UART2 tasks that the TCP client is shutting down
     online.tcpClient = false;
     delay(5);
-    Serial.println("TCP client offline");
+    systemPrintln("TCP client offline");
   }
 
   //Shutdown the TCP server connection
@@ -400,7 +400,7 @@ void wifiStop()
     //Wait for the UART2 tasks to close the TCP client connections
     while (wifiTcpServerActive())
       delay(5);
-    Serial.println("TCP Server offline");
+    systemPrintln("TCP Server offline");
   }
   
   if (wifiState == WIFI_OFF)
@@ -459,10 +459,10 @@ void wifiUpdate()
       && (wifiState == WIFI_CONNECTED))
   {
     online.tcpClient = true;
-    Serial.print("TCP client online, local IP ");
-    Serial.print(WiFi.localIP());
-    Serial.print(", gateway IP ");
-    Serial.println(WiFi.gatewayIP());
+    systemPrint("TCP client online, local IP ");
+    systemPrint(WiFi.localIP());
+    systemPrint(", gateway IP ");
+    systemPrintln(WiFi.gatewayIP());
   }
 
   //Start the TCP server if enabled
@@ -471,8 +471,8 @@ void wifiUpdate()
   {
     wifiTcpServer.begin();
     online.tcpServer = true;
-    Serial.print("TCP Server online, IP Address ");
-    Serial.println(WiFi.localIP());
+    systemPrint("TCP Server online, IP Address ");
+    systemPrintln(WiFi.localIP());
   }
 
   //Support NTRIP client during Rover operation

--- a/Firmware/RTK_Surveyor/bluetoothSelect.h
+++ b/Firmware/RTK_Surveyor/bluetoothSelect.h
@@ -14,9 +14,11 @@ class BTSerialInterface
 
     virtual int available() = 0;
     virtual size_t readBytes(uint8_t *buffer, size_t bufferSize) = 0;
+    virtual int read() = 0;
 
     //virtual bool isCongested() = 0;
     virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    virtual size_t write(uint8_t value) = 0;
     virtual void flush() = 0;
 };
 
@@ -61,15 +63,26 @@ class BTClassicSerial : public virtual BTSerialInterface, public BluetoothSerial
       return BluetoothSerial::readBytes(buffer, bufferSize);
     }
 
+    int read()
+    {
+      return BluetoothSerial::read();
+    }
+
     size_t write(const uint8_t *buffer, size_t size)
     {
       return BluetoothSerial::write(buffer, size);
+    }
+
+    size_t write(uint8_t value)
+    {
+      return BluetoothSerial::write(value);
     }
 
     void flush()
     {
       BluetoothSerial::flush();
     }
+
 };
 
 
@@ -114,9 +127,19 @@ class BTLESerial: public virtual BTSerialInterface, public BleSerial
       return BleSerial::readBytes(buffer, bufferSize);
     }
 
+    int read()
+    {
+      return BleSerial::read();
+    }
+
     size_t write(const uint8_t *buffer, size_t size)
     {
       return BleSerial::write(buffer, size);
+    }
+
+    size_t write(uint8_t value)
+    {
+      return BleSerial::write(value);
     }
 
     void flush()
@@ -142,6 +165,5 @@ class BTLESerial: public virtual BTSerialInterface, public BleSerial
     esp_spp_cb_t * connectionCallback;
 
 };
-
 
 #endif

--- a/Firmware/RTK_Surveyor/menuBase.ino
+++ b/Firmware/RTK_Surveyor/menuBase.ino
@@ -4,92 +4,92 @@ void menuBase()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Base");
+    systemPrintln();
+    systemPrintln("Menu: Base");
 
-    Serial.print("1) Toggle Base Mode: ");
-    if (settings.fixedBase == true) Serial.println("Fixed/Static Position");
-    else Serial.println("Use Survey-In");
+    systemPrint("1) Toggle Base Mode: ");
+    if (settings.fixedBase == true) systemPrintln("Fixed/Static Position");
+    else systemPrintln("Use Survey-In");
 
     if (settings.fixedBase == true)
     {
-      Serial.print("2) Toggle Coordinate System: ");
-      if (settings.fixedBaseCoordinateType == COORD_TYPE_ECEF) Serial.println("ECEF");
-      else Serial.println("Geodetic");
+      systemPrint("2) Toggle Coordinate System: ");
+      if (settings.fixedBaseCoordinateType == COORD_TYPE_ECEF) systemPrintln("ECEF");
+      else systemPrintln("Geodetic");
 
       if (settings.fixedBaseCoordinateType == COORD_TYPE_ECEF)
       {
-        Serial.print("3) Set ECEF X/Y/Z coordinates: ");
-        Serial.print(settings.fixedEcefX, 4);
-        Serial.print("m, ");
-        Serial.print(settings.fixedEcefY, 4);
-        Serial.print("m, ");
-        Serial.print(settings.fixedEcefZ, 4);
-        Serial.println("m");
+        systemPrint("3) Set ECEF X/Y/Z coordinates: ");
+        systemPrint(settings.fixedEcefX, 4);
+        systemPrint("m, ");
+        systemPrint(settings.fixedEcefY, 4);
+        systemPrint("m, ");
+        systemPrint(settings.fixedEcefZ, 4);
+        systemPrintln("m");
       }
       else if (settings.fixedBaseCoordinateType == COORD_TYPE_GEODETIC)
       {
-        Serial.print("3) Set Lat/Long/Altitude coordinates: ");
-        Serial.print(settings.fixedLat, haeNumberOfDecimals);
+        systemPrint("3) Set Lat/Long/Altitude coordinates: ");
+        systemPrint(settings.fixedLat, haeNumberOfDecimals);
         Serial.write(167); //°
-        Serial.print(", ");
-        Serial.print(settings.fixedLong, haeNumberOfDecimals);
+        systemPrint(", ");
+        systemPrint(settings.fixedLong, haeNumberOfDecimals);
         Serial.write(167); //°
-        Serial.print(", ");
-        Serial.print(settings.fixedAltitude, 4);
-        Serial.println("m");
+        systemPrint(", ");
+        systemPrint(settings.fixedAltitude, 4);
+        systemPrintln("m");
 
-        Serial.printf("4) Set Antenna Height: %dmm\r\n", settings.antennaHeight);
+        systemPrintf("4) Set Antenna Height: %dmm\r\n", settings.antennaHeight);
 
-        Serial.printf("5) Set Antenna Reference Point: %0.1fmm\r\n", settings.antennaReferencePoint);
+        systemPrintf("5) Set Antenna Reference Point: %0.1fmm\r\n", settings.antennaReferencePoint);
       }
     }
     else
     {
-      Serial.print("2) Set minimum observation time: ");
-      Serial.print(settings.observationSeconds);
-      Serial.println(" seconds");
+      systemPrint("2) Set minimum observation time: ");
+      systemPrint(settings.observationSeconds);
+      systemPrintln(" seconds");
 
-      Serial.print("3) Set required Mean 3D Standard Deviation: ");
-      Serial.print(settings.observationPositionAccuracy, 3);
-      Serial.println(" meters");
+      systemPrint("3) Set required Mean 3D Standard Deviation: ");
+      systemPrint(settings.observationPositionAccuracy, 3);
+      systemPrintln(" meters");
 
-      Serial.print("4) Set required initial positional accuracy before Survey-In: ");
-      Serial.print(settings.surveyInStartingAccuracy, 3);
-      Serial.println(" meters");
+      systemPrint("4) Set required initial positional accuracy before Survey-In: ");
+      systemPrint(settings.surveyInStartingAccuracy, 3);
+      systemPrintln(" meters");
     }
 
-    Serial.print("6) Toggle NTRIP Server: ");
-    if (settings.enableNtripServer == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("6) Toggle NTRIP Server: ");
+    if (settings.enableNtripServer == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
     if (settings.enableNtripServer == true)
     {
-      Serial.print("7) Set WiFi SSID: ");
-      Serial.println(settings.ntripServer_wifiSSID);
+      systemPrint("7) Set WiFi SSID: ");
+      systemPrintln(settings.ntripServer_wifiSSID);
 
-      Serial.print("8) Set WiFi PW: ");
-      Serial.println(settings.ntripServer_wifiPW);
+      systemPrint("8) Set WiFi PW: ");
+      systemPrintln(settings.ntripServer_wifiPW);
 
-      Serial.print("9) Set Caster Address: ");
-      Serial.println(settings.ntripServer_CasterHost);
+      systemPrint("9) Set Caster Address: ");
+      systemPrintln(settings.ntripServer_CasterHost);
 
-      Serial.print("10) Set Caster Port: ");
-      Serial.println(settings.ntripServer_CasterPort);
+      systemPrint("10) Set Caster Port: ");
+      systemPrintln(settings.ntripServer_CasterPort);
 
-      Serial.print("11) Set Mountpoint: ");
-      Serial.println(settings.ntripServer_MountPoint);
+      systemPrint("11) Set Mountpoint: ");
+      systemPrintln(settings.ntripServer_MountPoint);
 
-      Serial.print("12) Set Mountpoint PW: ");
-      Serial.println(settings.ntripServer_MountPointPW);
+      systemPrint("12) Set Mountpoint PW: ");
+      systemPrintln(settings.ntripServer_MountPointPW);
     }
 
     if (!settings.fixedBase) {
-      Serial.print("13) Select survey-in radio: ");
-      Serial.printf("%s\r\n", settings.ntripServer_StartAtSurveyIn ? "WiFi" : "Bluetooth");
+      systemPrint("13) Select survey-in radio: ");
+      systemPrintf("%s\r\n", settings.ntripServer_StartAtSurveyIn ? "WiFi" : "Bluetooth");
     }
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -108,9 +108,9 @@ void menuBase()
     {
       if (settings.fixedBaseCoordinateType == COORD_TYPE_ECEF)
       {
-        Serial.println("Enter the fixed ECEF coordinates that will be used in Base mode:");
+        systemPrintln("Enter the fixed ECEF coordinates that will be used in Base mode:");
 
-        Serial.print("ECEF X in meters (ex: -1280182.9200): ");
+        systemPrint("ECEF X in meters (ex: -1280182.9200): ");
         double fixedEcefX = getDouble();
 
         //Progress with additional prompts only if the user enters valid data
@@ -118,13 +118,13 @@ void menuBase()
         {
           settings.fixedEcefX = fixedEcefX;
 
-          Serial.print("\nECEF Y in meters (ex: -4716808.5807): ");
+          systemPrint("\nECEF Y in meters (ex: -4716808.5807): ");
           double fixedEcefY = getDouble();
           if (fixedEcefY != INPUT_RESPONSE_GETNUMBER_TIMEOUT && fixedEcefY != INPUT_RESPONSE_GETNUMBER_EXIT)
           {
             settings.fixedEcefY = fixedEcefY;
 
-            Serial.print("\nECEF Z in meters (ex: 4086669.6393): ");
+            systemPrint("\nECEF Z in meters (ex: 4086669.6393): ");
             double fixedEcefZ = getDouble();
             if (fixedEcefZ != INPUT_RESPONSE_GETNUMBER_TIMEOUT && fixedEcefZ != INPUT_RESPONSE_GETNUMBER_EXIT)
               settings.fixedEcefZ = fixedEcefZ;
@@ -133,9 +133,9 @@ void menuBase()
       }
       else  if (settings.fixedBaseCoordinateType == COORD_TYPE_GEODETIC)
       {
-        Serial.println("Enter the fixed Lat/Long/Altitude coordinates that will be used in Base mode:");
+        systemPrintln("Enter the fixed Lat/Long/Altitude coordinates that will be used in Base mode:");
 
-        Serial.print("Lat in degrees (ex: 40.090335429): ");
+        systemPrint("Lat in degrees (ex: 40.090335429): ");
         double fixedLat = getDouble();
 
         //Progress with additional prompts only if the user enters valid data
@@ -143,13 +143,13 @@ void menuBase()
         {
           settings.fixedLat = fixedLat;
 
-          Serial.print("\nLong in degrees (ex: -105.184774720): ");
+          systemPrint("\nLong in degrees (ex: -105.184774720): ");
           double fixedLong = getDouble();
           if (fixedLong != INPUT_RESPONSE_GETNUMBER_TIMEOUT && fixedLong != INPUT_RESPONSE_GETNUMBER_EXIT)
           {
             settings.fixedLong = fixedLong;
 
-            Serial.print("\nAltitude in meters (ex: 1560.2284): ");
+            systemPrint("\nAltitude in meters (ex: 1560.2284): ");
             double fixedAltitude = getDouble();
             if (fixedAltitude != INPUT_RESPONSE_GETNUMBER_TIMEOUT && fixedAltitude != INPUT_RESPONSE_GETNUMBER_EXIT)
               settings.fixedAltitude = fixedAltitude;
@@ -159,57 +159,57 @@ void menuBase()
     }
     else if (settings.fixedBase == true && settings.fixedBaseCoordinateType == COORD_TYPE_GEODETIC && incoming == 4)
     {
-      Serial.print("Enter the antenna height (a.k.a. pole length) in millimeters (-15000 to 15000mm): ");
+      systemPrint("Enter the antenna height (a.k.a. pole length) in millimeters (-15000 to 15000mm): ");
       int antennaHeight = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((antennaHeight != INPUT_RESPONSE_GETNUMBER_EXIT) && (antennaHeight != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (antennaHeight < -15000 || antennaHeight > 15000) //Arbitrary 15m max
-          Serial.println("Error: Antenna Height out of range");
+          systemPrintln("Error: Antenna Height out of range");
         else
           settings.antennaHeight = antennaHeight; //Recorded to NVM and file at main menu exit
       }
     }
     else if (settings.fixedBase == true && settings.fixedBaseCoordinateType == COORD_TYPE_GEODETIC && incoming == 5)
     {
-      Serial.print("Enter the antenna reference point (a.k.a. ARP) in millimeters (-200.0 to 200.0mm): ");
+      systemPrint("Enter the antenna reference point (a.k.a. ARP) in millimeters (-200.0 to 200.0mm): ");
       float antennaReferencePoint = getDouble();
       if (antennaReferencePoint < -200.0 || antennaReferencePoint > 200.0) //Arbitrary 200mm max
-        Serial.println("Error: Antenna Reference Point out of range");
+        systemPrintln("Error: Antenna Reference Point out of range");
       else
         settings.antennaReferencePoint = antennaReferencePoint; //Recorded to NVM and file at main menu exit
     }
 
     else if (settings.fixedBase == false && incoming == 2)
     {
-      Serial.print("Enter the number of seconds for survey-in obseration time (60 to 600s): ");
+      systemPrint("Enter the number of seconds for survey-in obseration time (60 to 600s): ");
       int observationSeconds = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((observationSeconds != INPUT_RESPONSE_GETNUMBER_EXIT) && (observationSeconds != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (observationSeconds < 60 || observationSeconds > 60 * 10) //Arbitrary 10 minute limit
-          Serial.println("Error: Observation seconds out of range");
+          systemPrintln("Error: Observation seconds out of range");
         else
           settings.observationSeconds = observationSeconds; //Recorded to NVM and file at main menu exit
       }
     }
     else if (settings.fixedBase == false && incoming == 3)
     {
-      Serial.print("Enter the number of meters for survey-in required position accuracy (1.0 to 5.0m): ");
+      systemPrint("Enter the number of meters for survey-in required position accuracy (1.0 to 5.0m): ");
       float observationPositionAccuracy = getDouble();
 #ifdef ENABLE_DEVELOPER
       if (observationPositionAccuracy < 1.0 || observationPositionAccuracy > 10.0) //Arbitrary 1m minimum
 #else
       if (observationPositionAccuracy < 1.0 || observationPositionAccuracy > 5.0) //Arbitrary 1m minimum
 #endif
-        Serial.println("Error: Observation positional accuracy requirement out of range");
+        systemPrintln("Error: Observation positional accuracy requirement out of range");
       else
         settings.observationPositionAccuracy = observationPositionAccuracy; //Recorded to NVM and file at main menu exit
     }
     else if (settings.fixedBase == false && incoming == 4)
     {
-      Serial.print("Enter the positional accuracy required before Survey-In begins (0.1 to 5.0m): ");
+      systemPrint("Enter the positional accuracy required before Survey-In begins (0.1 to 5.0m): ");
       float surveyInStartingAccuracy = getDouble();
       if (surveyInStartingAccuracy < 0.1 || surveyInStartingAccuracy > 5.0) //Arbitrary 0.1m minimum
-        Serial.println("Error: Starting accuracy out of range");
+        systemPrintln("Error: Starting accuracy out of range");
       else
         settings.surveyInStartingAccuracy = surveyInStartingAccuracy; //Recorded to NVM and file at main menu exit
     }
@@ -221,31 +221,31 @@ void menuBase()
     }
     else if (incoming == 7 && settings.enableNtripServer == true)
     {
-      Serial.print("Enter local WiFi SSID: ");
+      systemPrint("Enter local WiFi SSID: ");
       getString(settings.ntripServer_wifiSSID, sizeof(settings.ntripServer_wifiSSID));
       restartBase = true;
     }
     else if (incoming == 8 && settings.enableNtripServer == true)
     {
-      Serial.printf("Enter password for WiFi network %s: ", settings.ntripServer_wifiSSID);
+      systemPrintf("Enter password for WiFi network %s: ", settings.ntripServer_wifiSSID);
       getString(settings.ntripServer_wifiPW, sizeof(settings.ntripServer_wifiPW));
       restartBase = true;
     }
     else if (incoming == 9 && settings.enableNtripServer == true)
     {
-      Serial.print("Enter new Caster Address: ");
+      systemPrint("Enter new Caster Address: ");
       getString(settings.ntripServer_CasterHost, sizeof(settings.ntripServer_CasterHost));
       restartBase = true;
     }
     else if (incoming == 10 && settings.enableNtripServer == true)
     {
-      Serial.print("Enter new Caster Port: ");
+      systemPrint("Enter new Caster Port: ");
 
       int ntripServer_CasterPort = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((ntripServer_CasterPort != INPUT_RESPONSE_GETNUMBER_EXIT) && (ntripServer_CasterPort != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (ntripServer_CasterPort < 1 || ntripServer_CasterPort > 99999) //Arbitrary 99k max port #
-          Serial.println("Error: Caster port out of range");
+          systemPrintln("Error: Caster port out of range");
         else
           settings.ntripServer_CasterPort = ntripServer_CasterPort; //Recorded to NVM and file at main menu exit
         restartBase = true;
@@ -253,13 +253,13 @@ void menuBase()
     }
     else if (incoming == 11 && settings.enableNtripServer == true)
     {
-      Serial.print("Enter new Mount Point: ");
+      systemPrint("Enter new Mount Point: ");
       getString(settings.ntripServer_MountPoint, sizeof(settings.ntripServer_MountPoint));
       restartBase = true;
     }
     else if (incoming == 12 && settings.enableNtripServer == true)
     {
-      Serial.printf("Enter password for Mount Point %s: ", settings.ntripServer_MountPoint);
+      systemPrintf("Enter password for Mount Point %s: ", settings.ntripServer_MountPoint);
       getString(settings.ntripServer_MountPointPW, sizeof(settings.ntripServer_MountPointPW));
       restartBase = true;
     }
@@ -284,33 +284,33 @@ void menuSensorFusion()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Sensor Fusion");
+    systemPrintln();
+    systemPrintln("Menu: Sensor Fusion");
 
-    Serial.print("Fusion Mode: ");
-    Serial.print(i2cGNSS.packetUBXESFSTATUS->data.fusionMode);
-    Serial.print(" - ");
+    systemPrint("Fusion Mode: ");
+    systemPrint(i2cGNSS.packetUBXESFSTATUS->data.fusionMode);
+    systemPrint(" - ");
     if (i2cGNSS.packetUBXESFSTATUS->data.fusionMode == 0)
-      Serial.println("Initializing");
+      systemPrintln("Initializing");
     else if (i2cGNSS.packetUBXESFSTATUS->data.fusionMode == 1)
-      Serial.println("Calibrated");
+      systemPrintln("Calibrated");
     else if (i2cGNSS.packetUBXESFSTATUS->data.fusionMode == 2)
-      Serial.println("Suspended");
+      systemPrintln("Suspended");
     else if (i2cGNSS.packetUBXESFSTATUS->data.fusionMode == 3)
-      Serial.println("Disabled");
+      systemPrintln("Disabled");
 
     if (settings.enableSensorFusion == true && settings.dynamicModel != DYN_MODEL_AUTOMOTIVE)
-      Serial.println("Warning: Dynamic Model not set to Automotive. Sensor Fusion is best used with the Automotive Dynamic Model.");
+      systemPrintln("Warning: Dynamic Model not set to Automotive. Sensor Fusion is best used with the Automotive Dynamic Model.");
 
-    Serial.print("1) Toggle Sensor Fusion: ");
-    if (settings.enableSensorFusion == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("1) Toggle Sensor Fusion: ");
+    if (settings.enableSensorFusion == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("2) Toggle Automatic IMU-mount Alignment: ");
-    if (settings.autoIMUmountAlignment == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("2) Toggle Automatic IMU-mount Alignment: ");
+    if (settings.autoIMUmountAlignment == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -440,7 +440,7 @@ bool getFileLineSD(const char* fileName, int lineToFind, char* lineData, int lin
         int n = file.fgets(lineData, lineDataLength); //Use with SdFat library
         if (n <= 0)
         {
-          Serial.printf("Failed to read line %d from settings file\r\n", lineNumber);
+          systemPrintf("Failed to read line %d from settings file\r\n", lineNumber);
           break;
         }
         else
@@ -461,7 +461,7 @@ bool getFileLineSD(const char* fileName, int lineToFind, char* lineData, int lin
     } //End Semaphore check
     else
     {
-      Serial.printf("sdCardSemaphore failed to yield, menuBase.ino line %d\r\n", __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, menuBase.ino line %d\r\n", __LINE__);
     }
     break;
   } //End SD online
@@ -517,7 +517,7 @@ bool removeFileSD(const char* fileName)
     } //End Semaphore check
     else
     {
-      Serial.printf("sdCardSemaphore failed to yield, menuBase.ino line %d\r\n", __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, menuBase.ino line %d\r\n", __LINE__);
     }
     break;
   } //End SD online
@@ -588,7 +588,7 @@ void recordLineToSD(const char* fileName, const char* lineData)
     } //End Semaphore check
     else
     {
-      Serial.printf("sdCardSemaphore failed to yield, menuBase.ino line %d\r\n", __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, menuBase.ino line %d\r\n", __LINE__);
     }
     break;
   } //End SD online
@@ -606,7 +606,7 @@ void recordLineToLFS(const char* fileName, const char* lineData)
   File file = LittleFS.open(fileName, FILE_APPEND);
   if (!file)
   {
-    Serial.printf("File %s failed to create\n\r", fileName);
+    systemPrintf("File %s failed to create\n\r", fileName);
     return;
   }
 

--- a/Firmware/RTK_Surveyor/menuGNSS.ino
+++ b/Firmware/RTK_Surveyor/menuGNSS.ino
@@ -6,105 +6,105 @@ void menuGNSS()
 
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: GNSS Receiver");
+    systemPrintln();
+    systemPrintln("Menu: GNSS Receiver");
 
     //Because we may be in base mode (always 1Hz), do not get freq from module, use settings instead
     float measurementFrequency = (1000.0 / settings.measurementRate) / settings.navigationRate;
 
-    Serial.print("1) Set measurement rate in Hz: ");
-    Serial.println(measurementFrequency, 5);
+    systemPrint("1) Set measurement rate in Hz: ");
+    systemPrintln(measurementFrequency, 5);
 
-    Serial.print("2) Set measurement rate in seconds between measurements: ");
-    Serial.println(1 / measurementFrequency, 5);
+    systemPrint("2) Set measurement rate in seconds between measurements: ");
+    systemPrintln(1 / measurementFrequency, 5);
 
-    Serial.print("3) Set dynamic model: ");
+    systemPrint("3) Set dynamic model: ");
     switch (settings.dynamicModel)
     {
       case DYN_MODEL_PORTABLE:
-        Serial.print("Portable");
+        systemPrint("Portable");
         break;
       case DYN_MODEL_STATIONARY:
-        Serial.print("Stationary");
+        systemPrint("Stationary");
         break;
       case DYN_MODEL_PEDESTRIAN:
-        Serial.print("Pedestrian");
+        systemPrint("Pedestrian");
         break;
       case DYN_MODEL_AUTOMOTIVE:
-        Serial.print("Automotive");
+        systemPrint("Automotive");
         break;
       case DYN_MODEL_SEA:
-        Serial.print("Sea");
+        systemPrint("Sea");
         break;
       case DYN_MODEL_AIRBORNE1g:
-        Serial.print("Airborne 1g");
+        systemPrint("Airborne 1g");
         break;
       case DYN_MODEL_AIRBORNE2g:
-        Serial.print("Airborne 2g");
+        systemPrint("Airborne 2g");
         break;
       case DYN_MODEL_AIRBORNE4g:
-        Serial.print("Airborne 4g");
+        systemPrint("Airborne 4g");
         break;
       case DYN_MODEL_WRIST:
-        Serial.print("Wrist");
+        systemPrint("Wrist");
         break;
       case DYN_MODEL_BIKE:
-        Serial.print("Bike");
+        systemPrint("Bike");
         break;
       default:
-        Serial.print("Unknown");
+        systemPrint("Unknown");
         break;
     }
-    Serial.println();
+    systemPrintln();
 
-    Serial.println("4) Set Constellations");
+    systemPrintln("4) Set Constellations");
 
-    Serial.print("5) Toggle NTRIP Client: ");
-    if (settings.enableNtripClient == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("5) Toggle NTRIP Client: ");
+    if (settings.enableNtripClient == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
     if (settings.enableNtripClient == true)
     {
-      Serial.print("6) Set WiFi SSID: ");
-      Serial.println(settings.ntripClient_wifiSSID);
+      systemPrint("6) Set WiFi SSID: ");
+      systemPrintln(settings.ntripClient_wifiSSID);
 
-      Serial.print("7) Set WiFi PW: ");
-      Serial.println(settings.ntripClient_wifiPW);
+      systemPrint("7) Set WiFi PW: ");
+      systemPrintln(settings.ntripClient_wifiPW);
 
-      Serial.print("8) Set Caster Address: ");
-      Serial.println(settings.ntripClient_CasterHost);
+      systemPrint("8) Set Caster Address: ");
+      systemPrintln(settings.ntripClient_CasterHost);
 
-      Serial.print("9) Set Caster Port: ");
-      Serial.println(settings.ntripClient_CasterPort);
+      systemPrint("9) Set Caster Port: ");
+      systemPrintln(settings.ntripClient_CasterPort);
 
-      Serial.print("10) Set Caster User Name: ");
-      Serial.println(settings.ntripClient_CasterUser);
+      systemPrint("10) Set Caster User Name: ");
+      systemPrintln(settings.ntripClient_CasterUser);
 
-      Serial.print("11) Set Caster User Password: ");
-      Serial.println(settings.ntripClient_CasterUserPW);
+      systemPrint("11) Set Caster User Password: ");
+      systemPrintln(settings.ntripClient_CasterUserPW);
 
-      Serial.print("12) Set Mountpoint: ");
-      Serial.println(settings.ntripClient_MountPoint);
+      systemPrint("12) Set Mountpoint: ");
+      systemPrintln(settings.ntripClient_MountPoint);
 
-      Serial.print("13) Set Mountpoint PW: ");
-      Serial.println(settings.ntripClient_MountPointPW);
+      systemPrint("13) Set Mountpoint PW: ");
+      systemPrintln(settings.ntripClient_MountPointPW);
 
-      Serial.print("14) Toggle sending GGA Location to Caster: ");
-      if (settings.ntripClient_TransmitGGA == true) Serial.println("Enabled");
-      else Serial.println("Disabled");
+      systemPrint("14) Toggle sending GGA Location to Caster: ");
+      if (settings.ntripClient_TransmitGGA == true) systemPrintln("Enabled");
+      else systemPrintln("Disabled");
     }
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
     if (incoming == 1)
     {
-      Serial.print("Enter GNSS measurement rate in Hz: ");
+      systemPrint("Enter GNSS measurement rate in Hz: ");
       double rate = getDouble();
       if (rate < 0.00012 || rate > 20.0) //20Hz limit with all constellations enabled
       {
-        Serial.println("Error: Measurement rate out of range");
+        systemPrintln("Error: Measurement rate out of range");
       }
       else
       {
@@ -114,11 +114,11 @@ void menuGNSS()
     }
     else if (incoming == 2)
     {
-      Serial.print("Enter GNSS measurement rate in seconds between measurements: ");
+      systemPrint("Enter GNSS measurement rate in seconds between measurements: ");
       float rate = getDouble();
       if (rate < 0.0 || rate > 8255.0) //Limit of 127 (navRate) * 65000ms (measRate) = 137 minute limit.
       {
-        Serial.println("Error: Measurement rate out of range");
+        systemPrintln("Error: Measurement rate out of range");
       }
       else
       {
@@ -128,23 +128,23 @@ void menuGNSS()
     }
     else if (incoming == 3)
     {
-      Serial.println("Enter the dynamic model to use: ");
-      Serial.println("1) Portable");
-      Serial.println("2) Stationary");
-      Serial.println("3) Pedestrian");
-      Serial.println("4) Automotive");
-      Serial.println("5) Sea");
-      Serial.println("6) Airborne 1g");
-      Serial.println("7) Airborne 2g");
-      Serial.println("8) Airborne 4g");
-      Serial.println("9) Wrist");
-      Serial.println("10) Bike");
+      systemPrintln("Enter the dynamic model to use: ");
+      systemPrintln("1) Portable");
+      systemPrintln("2) Stationary");
+      systemPrintln("3) Pedestrian");
+      systemPrintln("4) Automotive");
+      systemPrintln("5) Sea");
+      systemPrintln("6) Airborne 1g");
+      systemPrintln("7) Airborne 2g");
+      systemPrintln("8) Airborne 4g");
+      systemPrintln("9) Wrist");
+      systemPrintln("10) Bike");
 
       int dynamicModel = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((dynamicModel != INPUT_RESPONSE_GETNUMBER_EXIT) && (dynamicModel != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (dynamicModel < 1 || dynamicModel > DYN_MODEL_BIKE)
-          Serial.println("Error: Dynamic model out of range");
+          systemPrintln("Error: Dynamic model out of range");
         else
         {
           if (dynamicModel == 1)
@@ -165,31 +165,31 @@ void menuGNSS()
     }
     else if (incoming == 6 && settings.enableNtripClient == true)
     {
-      Serial.print("Enter local WiFi SSID: ");
+      systemPrint("Enter local WiFi SSID: ");
       getString(settings.ntripClient_wifiSSID, sizeof(settings.ntripClient_wifiSSID));
       restartRover = true;
     }
     else if (incoming == 7 && settings.enableNtripClient == true)
     {
-      Serial.printf("Enter password for WiFi network %s: ", settings.ntripClient_wifiSSID);
+      systemPrintf("Enter password for WiFi network %s: ", settings.ntripClient_wifiSSID);
       getString(settings.ntripClient_wifiPW, sizeof(settings.ntripClient_wifiPW));
       restartRover = true;
     }
     else if (incoming == 8 && settings.enableNtripClient == true)
     {
-      Serial.print("Enter new Caster Address: ");
+      systemPrint("Enter new Caster Address: ");
       getString(settings.ntripClient_CasterHost, sizeof(settings.ntripClient_CasterHost));
       restartRover = true;
     }
     else if (incoming == 9 && settings.enableNtripClient == true)
     {
-      Serial.print("Enter new Caster Port: ");
+      systemPrint("Enter new Caster Port: ");
 
       int ntripClient_CasterPort = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((ntripClient_CasterPort != INPUT_RESPONSE_GETNUMBER_EXIT) && (ntripClient_CasterPort != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (ntripClient_CasterPort < 1 || ntripClient_CasterPort > 99999) //Arbitrary 99k max port #
-          Serial.println("Error: Caster port out of range");
+          systemPrintln("Error: Caster port out of range");
         else
           settings.ntripClient_CasterPort = ntripClient_CasterPort; //Recorded to NVM and file at main menu exit
         restartRover = true;
@@ -197,25 +197,25 @@ void menuGNSS()
     }
     else if (incoming == 10 && settings.enableNtripClient == true)
     {
-      Serial.printf("Enter user name for %s: ", settings.ntripClient_CasterHost);
+      systemPrintf("Enter user name for %s: ", settings.ntripClient_CasterHost);
       getString(settings.ntripClient_CasterUser, sizeof(settings.ntripClient_CasterUser));
       restartRover = true;
     }
     else if (incoming == 11 && settings.enableNtripClient == true)
     {
-      Serial.printf("Enter user password for %s: ", settings.ntripClient_CasterHost);
+      systemPrintf("Enter user password for %s: ", settings.ntripClient_CasterHost);
       getString(settings.ntripClient_CasterUserPW, sizeof(settings.ntripClient_CasterUserPW));
       restartRover = true;
     }
     else if (incoming == 12 && settings.enableNtripClient == true)
     {
-      Serial.print("Enter new Mount Point: ");
+      systemPrint("Enter new Mount Point: ");
       getString(settings.ntripClient_MountPoint, sizeof(settings.ntripClient_MountPoint));
       restartRover = true;
     }
     else if (incoming == 13 && settings.enableNtripClient == true)
     {
-      Serial.printf("Enter password for Mount Point %s: ", settings.ntripClient_MountPoint);
+      systemPrintf("Enter password for Mount Point %s: ", settings.ntripClient_MountPoint);
       getString(settings.ntripClient_MountPointPW, sizeof(settings.ntripClient_MountPointPW));
       restartRover = true;
     }
@@ -250,7 +250,7 @@ void menuGNSS()
     //Rudamentary user name length check
     if (strlen(settings.ntripClient_CasterUser) == 0)
     {
-      Serial.println("WARNING: RTK2Go requires that you use your email address as the mountpoint user name");
+      systemPrintln("WARNING: RTK2Go requires that you use your email address as the mountpoint user name");
       delay(2000);
     }
   }
@@ -266,20 +266,20 @@ void menuConstellations()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Constellations");
+    systemPrintln();
+    systemPrintln("Menu: Constellations");
 
     for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
     {
-      Serial.printf("%d) Constellation %s: ", x + 1, settings.ubxConstellations[x].textName);
+      systemPrintf("%d) Constellation %s: ", x + 1, settings.ubxConstellations[x].textName);
       if (settings.ubxConstellations[x].enabled == true)
-        Serial.print("Enabled");
+        systemPrint("Enabled");
       else
-        Serial.print("Disabled");
-      Serial.println();
+        systemPrint("Disabled");
+      systemPrintln();
     }
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -341,7 +341,7 @@ bool setRate(double secondsBetweenSolutions)
   navRate = secondsBetweenSolutions * 1000.0 / measRate; //Set navRate to nearest int value
   measRate = secondsBetweenSolutions * 1000.0 / navRate; //Adjust measurement rate to match actual navRate
 
-  //Serial.printf("measurementRate / navRate: %d / %d\r\n", measRate, navRate);
+  //systemPrintf("measurementRate / navRate: %d / %d\r\n", measRate, navRate);
 
   bool response = true;
   response &= i2cGNSS.newCfgValset();
@@ -369,7 +369,7 @@ bool setRate(double secondsBetweenSolutions)
   }
   else
   {
-    Serial.println("Failed to set measurement and navigation rates");
+    systemPrintln("Failed to set measurement and navigation rates");
     return (false);
   }
 
@@ -380,11 +380,11 @@ bool setRate(double secondsBetweenSolutions)
 void printZEDInfo()
 {
   if (zedModuleType == PLATFORM_F9P)
-    Serial.printf("ZED-F9P firmware: %s\r\n", zedFirmwareVersion);
+    systemPrintf("ZED-F9P firmware: %s\r\n", zedFirmwareVersion);
   else if (zedModuleType == PLATFORM_F9R)
-    Serial.printf("ZED-F9R firmware: %s\r\n", zedFirmwareVersion);
+    systemPrintf("ZED-F9R firmware: %s\r\n", zedFirmwareVersion);
   else
-    Serial.printf("Unknown module with firmware: %s\r\n", zedFirmwareVersion);
+    systemPrintf("Unknown module with firmware: %s\r\n", zedFirmwareVersion);
 }
 
 
@@ -392,5 +392,5 @@ void printZEDInfo()
 void printNEOInfo()
 {
   if (productVariant == RTK_FACET_LBAND)
-    Serial.printf("NEO-D9S firmware: %s\r\n", neoFirmwareVersion);
+    systemPrintf("NEO-D9S firmware: %s\r\n", neoFirmwareVersion);
 }

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -2,14 +2,14 @@
 //Report status if ~ received, otherwise present config menu
 void updateSerial()
 {
-  if (Serial.available())
+  if (systemAvailable())
   {
-    byte incoming = Serial.read();
+    byte incoming = systemRead();
 
     if (incoming == '~')
     {
       //Output custom GNTXT message with all current system data
-      printCurrentConditionsNMEA();
+      //printCurrentConditionsNMEA();
     }
     else
       menuMain(); //Present user menu
@@ -25,51 +25,54 @@ void menuMain()
 
   while (1)
   {
-    Serial.println();
+    systemPrintln();
 #ifdef ENABLE_DEVELOPER
-    Serial.printf("SparkFun RTK %s v%d.%d-RC-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
+    systemPrintf("SparkFun RTK %s v%d.%d-RC-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
 #else
-    Serial.printf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
+    systemPrintf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, __DATE__);
 #endif
 
 #ifdef COMPILE_BT
-    Serial.print("** Bluetooth broadcasting as: ");
-    Serial.print(deviceName);
-    Serial.println(" **");
+    systemPrint("** Bluetooth broadcasting as: ");
+    systemPrint(deviceName);
+    systemPrintln(" **");
 #else
-    Serial.println("** Bluetooth Not Compiled **");
+    systemPrintln("** Bluetooth Not Compiled **");
 #endif
 
-    Serial.println("Menu: Main");
+    systemPrintln("Menu: Main");
 
-    Serial.println("1) Configure GNSS Receiver");
+    systemPrintln("1) Configure GNSS Receiver");
 
-    Serial.println("2) Configure GNSS Messages");
+    systemPrintln("2) Configure GNSS Messages");
 
     if (zedModuleType == PLATFORM_F9P)
-      Serial.println("3) Configure Base");
+      systemPrintln("3) Configure Base");
     else if (zedModuleType == PLATFORM_F9R)
-      Serial.println("3) Configure Sensor Fusion");
+      systemPrintln("3) Configure Sensor Fusion");
 
-    Serial.println("4) Configure Ports");
+    systemPrintln("4) Configure Ports");
 
-    Serial.println("5) Configure Logging");
+    systemPrintln("5) Configure Logging");
 
-    Serial.println("p) Configure User Profiles");
+    systemPrintln("p) Configure User Profiles");
 
 #ifdef COMPILE_ESPNOW
-    Serial.println("r) Configure Radios");
+    systemPrintln("r) Configure Radios");
 #endif
 
     if (online.lband == true)
-      Serial.println("P) Configure PointPerfect");
+      systemPrintln("P) Configure PointPerfect");
 
-    Serial.println("s) Configure System");
+    systemPrintln("s) Configure System");
 
     if (binCount > 0)
-      Serial.println("f) Firmware upgrade");
+      systemPrintln("f) Firmware upgrade");
 
-    Serial.println("x) Exit");
+    if (btPrintEcho)
+      systemPrintln("b) Exit Bluetooth Echo mode");
+
+    systemPrintln("x) Exit");
 
     byte incoming = getCharacterNumber();
 
@@ -97,6 +100,13 @@ void menuMain()
 #endif
     else if (incoming == 'f' && binCount > 0)
       menuFirmware();
+    else if (incoming == 'b')
+    {
+      printEndpoint = PRINT_ENDPOINT_SERIAL;
+      systemPrintln("BT device has exited echo mode");
+      btPrintEcho = false;
+      break; //Exit config menu
+    }
     else if (incoming == 'x')
       break;
     else if (incoming == INPUT_RESPONSE_EMPTY)
@@ -145,29 +155,29 @@ void menuUserProfiles()
 
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: User Profiles");
+    systemPrintln();
+    systemPrintln("Menu: User Profiles");
 
     //List available profiles
     for (int x = 0 ; x < MAX_PROFILE_COUNT ; x++)
     {
       if (activeProfiles & (1 << x))
-        Serial.printf("%d) Select %s", x + 1, profileNames[x]);
+        systemPrintf("%d) Select %s", x + 1, profileNames[x]);
       else
-        Serial.printf("%d) Select (Empty)", x + 1);
+        systemPrintf("%d) Select (Empty)", x + 1);
 
-      if (x == profileNumber) Serial.print(" <- Current");
+      if (x == profileNumber) systemPrint(" <- Current");
 
-      Serial.println();
+      systemPrintln();
     }
 
-    Serial.printf("%d) Edit profile name: %s\r\n", MAX_PROFILE_COUNT + 1, profileNames[profileNumber]);
+    systemPrintf("%d) Edit profile name: %s\r\n", MAX_PROFILE_COUNT + 1, profileNames[profileNumber]);
 
-    Serial.printf("%d) Set profile '%s' to factory defaults\r\n", MAX_PROFILE_COUNT + 2, profileNames[profileNumber]);
+    systemPrintf("%d) Set profile '%s' to factory defaults\r\n", MAX_PROFILE_COUNT + 2, profileNames[profileNumber]);
 
-    Serial.printf("%d) Delete profile '%s'\r\n", MAX_PROFILE_COUNT + 3, profileNames[profileNumber]);
+    systemPrintf("%d) Delete profile '%s'\r\n", MAX_PROFILE_COUNT + 3, profileNames[profileNumber]);
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -177,14 +187,14 @@ void menuUserProfiles()
     }
     else if (incoming == MAX_PROFILE_COUNT + 1)
     {
-      Serial.print("Enter new profile name: ");
+      systemPrint("Enter new profile name: ");
       getString(settings.profileName, sizeof(settings.profileName));
       recordSystemSettings(); //We need to update this immediately in case user lists the available profiles again
       setProfileName(profileNumber);
     }
     else if (incoming == MAX_PROFILE_COUNT + 2)
     {
-      Serial.printf("\r\nReset profile '%s' to factory defaults. Press 'y' to confirm:", profileNames[profileNumber]);
+      systemPrintf("\r\nReset profile '%s' to factory defaults. Press 'y' to confirm:", profileNames[profileNumber]);
       byte bContinue = getCharacterNumber();
       if (bContinue == 'y')
       {
@@ -198,11 +208,11 @@ void menuUserProfiles()
         forceReset = true; //Upon exit of menu, reset the device
       }
       else
-        Serial.println("Reset aborted");
+        systemPrintln("Reset aborted");
     }
     else if (incoming == MAX_PROFILE_COUNT + 3)
     {
-      Serial.printf("\r\nDelete profile '%s'. Press 'y' to confirm:", profileNames[profileNumber]);
+      systemPrintf("\r\nDelete profile '%s'. Press 'y' to confirm:", profileNames[profileNumber]);
       byte bContinue = getCharacterNumber();
       if (bContinue == 'y')
       {
@@ -236,7 +246,7 @@ void menuUserProfiles()
         activeProfiles = loadProfileNames();
       }
       else
-        Serial.println("Delete aborted");
+        systemPrintln("Delete aborted");
     }
 
     else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
@@ -249,7 +259,7 @@ void menuUserProfiles()
 
   if (originalProfileNumber != profileNumber || forceReset == true)
   {
-    Serial.println("Rebooting to apply new profile settings. Goodbye!");
+    systemPrintln("Rebooting to apply new profile settings. Goodbye!");
     delay(2000);
     ESP.restart();
   }
@@ -279,7 +289,7 @@ void changeProfileNumber(byte newProfileNumber)
   //If this is an empty/new profile slot, overwrite our current settings with defaults
   if (responseLFS == false && responseSD == false)
   {
-    Serial.println("Default the settings");
+    systemPrintln("Default the settings");
     settingsToDefaults();
   }
 }
@@ -301,7 +311,7 @@ void factoryReset()
 
       sd->remove(stationCoordinateECEFFileName); //Remove station files
       sd->remove(stationCoordinateGeodeticFileName);
-      
+
       xSemaphoreGive(sdCardSemaphore);
     } //End sdCardSemaphore
     else
@@ -309,17 +319,17 @@ void factoryReset()
       //An error occurs when a settings file is on the microSD card and it is not
       //deleted, as such the settings on the microSD card will be loaded when the
       //RTK reboots, resulting in failure to achieve the factory reset condition
-      Serial.printf("sdCardSemaphore failed to yield, menuMain.ino line %d\r\n", __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, menuMain.ino line %d\r\n", __LINE__);
     }
   }
-  
-  Serial.println("Formatting file system...");
+
+  systemPrintln("Formatting file system...");
   LittleFS.format();
 
   if (online.gnss == true)
     i2cGNSS.factoryReset(); //Reset everything: baud rate, I2C address, update rate, everything.
 
-  Serial.println("Settings erased successfully. Rebooting. Goodbye!");
+  systemPrintln("Settings erased successfully. Rebooting. Goodbye!");
   delay(2000);
   ESP.restart();
 }
@@ -330,46 +340,45 @@ void menuRadio()
 #ifdef COMPILE_ESPNOW
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Radios");
+    systemPrintln();
+    systemPrintln("Menu: Radios");
 
-    Serial.print("1) Select Radio Type: ");
-    if (settings.radioType == RADIO_EXTERNAL) Serial.println("External only");
-    else if (settings.radioType == RADIO_ESPNOW) Serial.println("Internal ESP-Now");
+    systemPrint("1) Select Radio Type: ");
+    if (settings.radioType == RADIO_EXTERNAL) systemPrintln("External only");
+    else if (settings.radioType == RADIO_ESPNOW) systemPrintln("Internal ESP-Now");
 
     if (settings.radioType == RADIO_ESPNOW)
     {
       //Pretty print the MAC of all radios
-      Serial.print("  Radio MAC: ");
+      systemPrint("  Radio MAC: ");
       for (int x = 0 ; x < 5 ; x++)
-        Serial.printf("%02X:", wifiMACAddress[x]);
-      Serial.printf("%02X\r\n", wifiMACAddress[5]);
+        systemPrintf("%02X:", wifiMACAddress[x]);
+      systemPrintf("%02X\r\n", wifiMACAddress[5]);
 
       if (settings.espnowPeerCount > 0)
       {
-        Serial.println("  Paired Radios: ");
+        systemPrintln("  Paired Radios: ");
         for (int x = 0 ; x < settings.espnowPeerCount ; x++)
         {
-          Serial.print("    ");
+          systemPrint("    ");
           for (int y = 0 ; y < 5 ; y++)
-            Serial.printf("%02X:", settings.espnowPeers[x][y]);
-          Serial.printf("%02X\r\n", settings.espnowPeers[x][5]);
+            systemPrintf("%02X:", settings.espnowPeers[x][y]);
+          systemPrintf("%02X\r\n", settings.espnowPeers[x][5]);
         }
       }
       else
-        Serial.println("  No Paired Radios");
+        systemPrintln("  No Paired Radios");
 
-
-      Serial.println("2) Pair radios");
-      Serial.println("3) Forget all radios");
+      systemPrintln("2) Pair radios");
+      systemPrintln("3) Forget all radios");
 #ifdef ENABLE_DEVELOPER
-      Serial.println("4) Add dummy radio");
-      Serial.println("5) Send dummy data");
-      Serial.println("6) Broadcast dummy data");
+      systemPrintln("4) Add dummy radio");
+      systemPrintln("5) Send dummy data");
+      systemPrintln("6) Broadcast dummy data");
 #endif
     }
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -384,7 +393,7 @@ void menuRadio()
     }
     else if (settings.radioType == RADIO_ESPNOW && incoming == 3)
     {
-      Serial.println("\r\nForgetting all paired radios. Press 'y' to confirm:");
+      systemPrintln("\r\nForgetting all paired radios. Press 'y' to confirm:");
       byte bContinue = getCharacterNumber();
       if (bContinue == 'y')
       {
@@ -394,7 +403,7 @@ void menuRadio()
             espnowRemovePeer(settings.espnowPeers[x]);
         }
         settings.espnowPeerCount = 0;
-        Serial.println("Radios forgotten");
+        systemPrintln("Radios forgotten");
       }
     }
 #ifdef ENABLE_DEVELOPER

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -5,8 +5,8 @@ void menuLog()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Logging");
+    systemPrintln();
+    systemPrintln("Menu: Logging");
 
     if (settings.enableSD && online.microSD)
     {
@@ -18,47 +18,39 @@ void menuLog()
                stringHumanReadableSize(sdFreeSpace),
                sdFreeSpace
               );
-      Serial.println(myString);
-
-      //      Serial.print("Card Size: ");
-      //      Serial.print(stringHumanReadableSize(sdCardSize));
-      //      Serial.print(" (" + sdCardSize + " bytes)");
-      //      Serial.print(" / Free space: ");
-      //      Serial.print(stringHumanReadableSize(sdFreeSpace));
-      //      Serial.print(" (" + sdFreeSpace + " bytes)");
-      //      Serial.println();
+      systemPrintln(myString);
     }
     else
-      Serial.println("No microSD card is detected");
+      systemPrintln("No microSD card is detected");
 
-    Serial.printf("Buffer overruns: %d\n\r", bufferOverruns);
+    systemPrintf("Buffer overruns: %d\n\r", bufferOverruns);
 
-    Serial.print("1) Log to microSD: ");
-    if (settings.enableLogging == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("1) Log to microSD: ");
+    if (settings.enableLogging == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
     if (settings.enableLogging == true)
     {
-      Serial.print("2) Set max logging time: ");
-      Serial.print(settings.maxLogTime_minutes);
-      Serial.println(" minutes");
+      systemPrint("2) Set max logging time: ");
+      systemPrint(settings.maxLogTime_minutes);
+      systemPrintln(" minutes");
 
-      Serial.print("3) Set max log length: ");
-      Serial.print(settings.maxLogLength_minutes);
-      Serial.println(" minutes");
+      systemPrint("3) Set max log length: ");
+      systemPrint(settings.maxLogLength_minutes);
+      systemPrintln(" minutes");
 
-      if (online.logging == true) Serial.println("4) Start new log");
+      if (online.logging == true) systemPrintln("4) Start new log");
     }
 
-    Serial.print("5) Write Marks_date.csv file to microSD: ");
-    if (settings.enableMarksFile == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("5) Write Marks_date.csv file to microSD: ");
+    if (settings.enableMarksFile == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("6) Reset system if the SD card is detected but fails to initialize: ");
-    if (settings.forceResetOnSDFail == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("6) Reset system if the SD card is detected but fails to initialize: ");
+    if (settings.forceResetOnSDFail == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -74,24 +66,24 @@ void menuLog()
     }
     else if (incoming == 2 && settings.enableLogging == true)
     {
-      Serial.print("Enter max minutes before logging stops: ");
+      systemPrint("Enter max minutes before logging stops: ");
       int maxMinutes = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((maxMinutes != INPUT_RESPONSE_GETNUMBER_EXIT) && (maxMinutes != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (maxMinutes < 0 || maxMinutes > (60 * 24 * 365 * 2)) //Arbitrary 2 year limit. See https://github.com/sparkfun/SparkFun_RTK_Firmware/issues/86
-          Serial.println("Error: Max minutes out of range");
+          systemPrintln("Error: Max minutes out of range");
         else
           settings.maxLogTime_minutes = maxMinutes; //Recorded to NVM and file at main menu exit
       }
     }
     else if (incoming == 3 && settings.enableLogging == true)
     {
-      Serial.print("Enter max minutes of logging before new log is created: ");
+      systemPrint("Enter max minutes of logging before new log is created: ");
       int maxLogMinutes = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((maxLogMinutes != INPUT_RESPONSE_GETNUMBER_EXIT) && (maxLogMinutes != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (maxLogMinutes < 0 || maxLogMinutes > 60 * 48) //Arbitrary 48 hour limit
-          Serial.println("Error: Max minutes out of range");
+          systemPrintln("Error: Max minutes out of range");
         else
           settings.maxLogLength_minutes = maxLogMinutes; //Recorded to NVM and file at main menu exit
       }
@@ -128,26 +120,26 @@ void menuMessages()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: GNSS Messages");
+    systemPrintln();
+    systemPrintln("Menu: GNSS Messages");
 
-    Serial.printf("Active messages: %d\r\n", getActiveMessageCount());
+    systemPrintf("Active messages: %d\r\n", getActiveMessageCount());
 
-    Serial.println("1) Set NMEA Messages");
+    systemPrintln("1) Set NMEA Messages");
     if (zedModuleType == PLATFORM_F9P)
-      Serial.println("2) Set RTCM Messages");
+      systemPrintln("2) Set RTCM Messages");
     else if (zedModuleType == PLATFORM_F9R)
-      Serial.println("2) Set ESF Messages");
-    Serial.println("3) Set RXM Messages");
-    Serial.println("4) Set NAV Messages");
-    Serial.println("5) Set MON Messages");
-    Serial.println("6) Set TIM Messages");
-    Serial.println("7) Reset to Surveying Defaults (NMEAx5)");
-    Serial.println("8) Reset to PPP Logging Defaults (NMEAx5 + RXMx2)");
-    Serial.println("9) Turn off all messages");
-    Serial.println("10) Turn on all messages");
+      systemPrintln("2) Set ESF Messages");
+    systemPrintln("3) Set RXM Messages");
+    systemPrintln("4) Set NAV Messages");
+    systemPrintln("5) Set MON Messages");
+    systemPrintln("6) Set TIM Messages");
+    systemPrintln("7) Reset to Surveying Defaults (NMEAx5)");
+    systemPrintln("8) Reset to PPP Logging Defaults (NMEAx5 + RXMx2)");
+    systemPrintln("9) Turn off all messages");
+    systemPrintln("10) Turn on all messages");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -178,7 +170,7 @@ void menuMessages()
       setMessageRateByName("UBX_NMEA_GSV", measurementFrequency); //One report per second
 
       setMessageRateByName("UBX_NMEA_RMC", 1);
-      Serial.println("Reset to Surveying Defaults (NMEAx5)");
+      systemPrintln("Reset to Surveying Defaults (NMEAx5)");
     }
     else if (incoming == 8)
     {
@@ -196,17 +188,17 @@ void menuMessages()
 
       setMessageRateByName("UBX_RXM_RAWX", 1);
       setMessageRateByName("UBX_RXM_SFRBX", 1);
-      Serial.println("Reset to PPP Logging Defaults (NMEAx5 + RXMx2)");
+      systemPrintln("Reset to PPP Logging Defaults (NMEAx5 + RXMx2)");
     }
     else if (incoming == 9)
     {
       setGNSSMessageRates(settings.ubxMessages, 0); //Turn off all messages
-      Serial.println("All messages disabled");
+      systemPrintln("All messages disabled");
     }
     else if (incoming == 10)
     {
       setGNSSMessageRates(settings.ubxMessages, 1); //Turn on all messages to report once per fix
-      Serial.println("All messages enabled");
+      systemPrintln("All messages enabled");
     }
     else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
       break;
@@ -222,18 +214,18 @@ void menuMessages()
   bool response = setMessages(); //Does a complete open/closed val set
   if (response == false)
   {
-    Serial.println("menuMessages: Failed to enable UART1 messages - Try 1");
+    systemPrintln("menuMessages: Failed to enable UART1 messages - Try 1");
 
     response = setMessages(); //Does a complete open/closed val set
 
     if (response == false)
-      Serial.println("menuMessages: Failed to enable UART1 messages - Try 2");
+      systemPrintln("menuMessages: Failed to enable UART1 messages - Try 2");
     else
-      Serial.println("menuMessages: UART1 messages successfully enabled");
+      systemPrintln("menuMessages: UART1 messages successfully enabled");
   }
   else
   {
-    Serial.println("menuMessages: UART1 messages successfully enabled");
+    systemPrintln("menuMessages: UART1 messages successfully enabled");
   }
 
   setLoggingType(); //Update Standard, PPP, or custom for icon selection
@@ -245,8 +237,8 @@ void menuMessagesSubtype(const char* messageType)
 {
   while (1)
   {
-    Serial.println();
-    Serial.printf("Menu: Message %s\r\n", messageType);
+    systemPrintln();
+    systemPrintf("Menu: Message %s\r\n", messageType);
 
     int startOfBlock = 0;
     int endOfBlock = 0;
@@ -256,12 +248,12 @@ void menuMessagesSubtype(const char* messageType)
       //Check to see if this ZED platform supports this message
       if (settings.ubxMessages[x + startOfBlock].supported & zedModuleType)
       {
-        Serial.printf("%d) Message %s: ", x + 1, settings.ubxMessages[x + startOfBlock].msgTextName);
-        Serial.println(settings.ubxMessages[x + startOfBlock].msgRate);
+        systemPrintf("%d) Message %s: ", x + 1, settings.ubxMessages[x + startOfBlock].msgTextName);
+        systemPrintln(settings.ubxMessages[x + startOfBlock].msgRate);
       }
     }
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -288,7 +280,7 @@ void menuMessagesSubtype(const char* messageType)
 //Assign the given value to the message
 void inputMessageRate(ubxMsg &localMessage)
 {
-  Serial.printf("Enter %s message rate (0 to disable): ", localMessage.msgTextName);
+  systemPrintf("Enter %s message rate (0 to disable): ", localMessage.msgTextName);
   int rate = getNumber(); //Returns EXIT, TIMEOUT, or long
 
   if (rate == INPUT_RESPONSE_GETNUMBER_TIMEOUT || rate == INPUT_RESPONSE_GETNUMBER_EXIT)
@@ -296,8 +288,8 @@ void inputMessageRate(ubxMsg &localMessage)
 
   while (rate < 0 || rate > 255) //8 bit limit
   {
-    Serial.println("Error: Message rate out of range");
-    Serial.printf("Enter %s message rate (0 to disable): ", localMessage.msgTextName);
+    systemPrintln("Error: Message rate out of range");
+    systemPrintf("Enter %s message rate (0 to disable): ", localMessage.msgTextName);
     rate = getNumber(); //Returns EXIT, TIMEOUT, or long
 
     if (rate == INPUT_RESPONSE_GETNUMBER_TIMEOUT || rate == INPUT_RESPONSE_GETNUMBER_EXIT)
@@ -366,7 +358,7 @@ void beginLogging(const char *customFileName)
         ubxFile = new SdFile();
         if (!ubxFile)
         {
-          Serial.println("Failed to allocate ubxFile!");
+          systemPrintln("Failed to allocate ubxFile!");
           online.logging = false;
           return;
         }
@@ -382,7 +374,7 @@ void beginLogging(const char *customFileName)
         // O_WRITE - open for write
         if (ubxFile->open(fileName, O_CREAT | O_APPEND | O_WRITE) == false)
         {
-          Serial.printf("Failed to create GNSS UBX data file: %s\r\n", fileName);
+          systemPrintf("Failed to create GNSS UBX data file: %s\r\n", fileName);
           online.logging = false;
           xSemaphoreGive(sdCardSemaphore);
           return;
@@ -442,7 +434,7 @@ void beginLogging(const char *customFileName)
 
         if (reuseLastLog == true)
         {
-          Serial.println("Appending last available log");
+          systemPrintln("Appending last available log");
         }
 
         xSemaphoreGive(sdCardSemaphore);
@@ -455,7 +447,7 @@ void beginLogging(const char *customFileName)
         return;
       }
 
-      Serial.printf("Log file name: %s\r\n", fileName);
+      systemPrintf("Log file name: %s\r\n", fileName);
       online.logging = true;
     } //online.sd, enable.logging, online.rtc
   } //online.logging
@@ -489,7 +481,7 @@ void endLogging(bool gotSemaphore, bool releaseSemaphore)
 
       //Close down file system
       ubxFile->close();
-      Serial.println("Log file closed");
+      systemPrintln("Log file closed");
 
       //Done with the log file
       delete ubxFile;
@@ -577,7 +569,7 @@ bool findLastLog(char *lastLogName)
     {
       //Error when a log file exists on the microSD card, data should be appended
       //to the existing log file
-      Serial.printf("sdCardSemaphore failed to yield, menuMessages.ino line %d\r\n", __LINE__);
+      systemPrintf("sdCardSemaphore failed to yield, menuMessages.ino line %d\r\n", __LINE__);
     }
   }
 
@@ -631,7 +623,7 @@ bool setMessageRateByName(const char *msgName, uint8_t msgRate)
     }
   }
 
-  Serial.printf("setMessageRateByName: %s not found\r\n", msgName);
+  systemPrintf("setMessageRateByName: %s not found\r\n", msgName);
   return (false);
 }
 
@@ -644,7 +636,7 @@ uint8_t getMessageRateByName(const char *msgName)
       return (settings.ubxMessages[x].msgRate);
   }
 
-  Serial.printf("getMessageRateByName: %s not found\r\n", msgName);
+  systemPrintf("getMessageRateByName: %s not found\r\n", msgName);
   return (0);
 }
 
@@ -846,6 +838,6 @@ void updateLogTest()
       log_w("sdCardSemaphore failed to yield, menuMessages.ino line %d", __LINE__);
     }
 
-    Serial.printf("%s\r\n", logMessage);
+    systemPrintf("%s\r\n", logMessage);
   }
 }

--- a/Firmware/RTK_Surveyor/menuPP.ino
+++ b/Firmware/RTK_Surveyor/menuPP.ino
@@ -32,22 +32,22 @@ void menuPointPerfectKeys()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: PointPerfect Keys");
+    systemPrintln();
+    systemPrintln("Menu: PointPerfect Keys");
 
-    Serial.print("1) Set ThingStream Device Profile Token: ");
+    systemPrint("1) Set ThingStream Device Profile Token: ");
     if (strlen(settings.pointPerfectDeviceProfileToken) > 0)
-      Serial.println(settings.pointPerfectDeviceProfileToken);
+      systemPrintln(settings.pointPerfectDeviceProfileToken);
     else
-      Serial.println("Use SparkFun Token");
+      systemPrintln("Use SparkFun Token");
 
-    Serial.print("2) Set Current Key: ");
+    systemPrint("2) Set Current Key: ");
     if (strlen(settings.pointPerfectCurrentKey) > 0)
-      Serial.println(settings.pointPerfectCurrentKey);
+      systemPrintln(settings.pointPerfectCurrentKey);
     else
-      Serial.println("N/A");
+      systemPrintln("N/A");
 
-    Serial.print("3) Set Current Key Expiration Date (DD/MM/YYYY): ");
+    systemPrint("3) Set Current Key Expiration Date (DD/MM/YYYY): ");
     if (strlen(settings.pointPerfectCurrentKey) > 0 && settings.pointPerfectCurrentKeyStart > 0 && settings.pointPerfectCurrentKeyDuration > 0)
     {
       long long unixEpoch = thingstreamEpochToGPSEpoch(settings.pointPerfectCurrentKeyStart, settings.pointPerfectCurrentKeyDuration);
@@ -61,18 +61,18 @@ void menuPointPerfectKeys()
       long expYear;
       gpsWeekToWToDate(keyGPSWeek, keyGPSToW, &expDay, &expMonth, &expYear);
 
-      Serial.printf("%02ld/%02ld/%ld\r\n", expDay, expMonth, expYear);
+      systemPrintf("%02ld/%02ld/%ld\r\n", expDay, expMonth, expYear);
     }
     else
-      Serial.println("N/A");
+      systemPrintln("N/A");
 
-    Serial.print("4) Set Next Key: ");
+    systemPrint("4) Set Next Key: ");
     if (strlen(settings.pointPerfectNextKey) > 0)
-      Serial.println(settings.pointPerfectNextKey);
+      systemPrintln(settings.pointPerfectNextKey);
     else
-      Serial.println("N/A");
+      systemPrintln("N/A");
 
-    Serial.print("5) Set Next Key Expiration Date (DD/MM/YYYY): ");
+    systemPrint("5) Set Next Key Expiration Date (DD/MM/YYYY): ");
     if (strlen(settings.pointPerfectNextKey) > 0 && settings.pointPerfectNextKeyStart > 0 && settings.pointPerfectNextKeyDuration > 0)
     {
       long long unixEpoch = thingstreamEpochToGPSEpoch(settings.pointPerfectNextKeyStart, settings.pointPerfectNextKeyDuration);
@@ -86,36 +86,36 @@ void menuPointPerfectKeys()
       long expYear;
       gpsWeekToWToDate(keyGPSWeek, keyGPSToW, &expDay, &expMonth, &expYear);
 
-      Serial.printf("%02ld/%02ld/%ld\r\n", expDay, expMonth, expYear);
+      systemPrintf("%02ld/%02ld/%ld\r\n", expDay, expMonth, expYear);
     }
     else
-      Serial.println("N/A");
+      systemPrintln("N/A");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
     if (incoming == 1)
     {
-      Serial.print("Enter Device Profile Token: ");
+      systemPrint("Enter Device Profile Token: ");
       getString(settings.pointPerfectDeviceProfileToken, sizeof(settings.pointPerfectDeviceProfileToken));
     }
     else if (incoming == 2)
     {
-      Serial.print("Enter Current Key: ");
+      systemPrint("Enter Current Key: ");
       getString(settings.pointPerfectCurrentKey, sizeof(settings.pointPerfectCurrentKey));
     }
     else if (incoming == 3)
     {
       clearBuffer();
 
-      Serial.println("Enter Current Key Expiration Date: ");
+      systemPrintln("Enter Current Key Expiration Date: ");
       uint8_t expDay;
       uint8_t expMonth;
       uint16_t expYear;
       while (getDate(expDay, expMonth, expYear) == false)
       {
-        Serial.println("Date invalid. Please try again.");
+        systemPrintln("Date invalid. Please try again.");
       }
 
       dateToKeyStartDuration(expDay, expMonth, expYear, &settings.pointPerfectCurrentKeyStart, &settings.pointPerfectCurrentKeyDuration);
@@ -126,26 +126,26 @@ void menuPointPerfectKeys()
         settings.pointPerfectNextKeyStart = settings.pointPerfectCurrentKeyStart + settings.pointPerfectCurrentKeyDuration + 1; //Next key starts after current key
         settings.pointPerfectNextKeyDuration = settings.pointPerfectCurrentKeyDuration;
 
-        Serial.printf("  settings.pointPerfectNextKeyStart: %lld\r\n", settings.pointPerfectNextKeyStart);
-        Serial.printf("  settings.pointPerfectNextKeyDuration: %lld\r\n", settings.pointPerfectNextKeyDuration);
+        systemPrintf("  settings.pointPerfectNextKeyStart: %lld\r\n", settings.pointPerfectNextKeyStart);
+        systemPrintf("  settings.pointPerfectNextKeyDuration: %lld\r\n", settings.pointPerfectNextKeyDuration);
       }
     }
     else if (incoming == 4)
     {
-      Serial.print("Enter Next Key: ");
+      systemPrint("Enter Next Key: ");
       getString(settings.pointPerfectNextKey, sizeof(settings.pointPerfectNextKey));
     }
     else if (incoming == 5)
     {
       clearBuffer();
 
-      Serial.println("Enter Next Key Expiration Date: ");
+      systemPrintln("Enter Next Key Expiration Date: ");
       uint8_t expDay;
       uint8_t expMonth;
       uint16_t expYear;
       while (getDate(expDay, expMonth, expYear) == false)
       {
-        Serial.println("Date invalid. Please try again.");
+        systemPrintln("Date invalid. Please try again.");
       }
 
       dateToKeyStartDuration(expDay, expMonth, expYear, &settings.pointPerfectNextKeyStart, &settings.pointPerfectNextKeyDuration);
@@ -207,7 +207,7 @@ bool pointperfectProvisionDevice()
     {
       //Use the user's custom token
       strcpy(tokenString, settings.pointPerfectDeviceProfileToken);
-      Serial.printf("Using custom token: %s\r\n", tokenString);
+      systemPrintf("Using custom token: %s\r\n", tokenString);
     }
 
     pointPerfectAPIPost["token"] = tokenString;
@@ -218,7 +218,7 @@ bool pointperfectProvisionDevice()
     String json;
     serializeJson(pointPerfectAPIPost, json);
 
-    Serial.printf("Connecting to: %s\r\n", pointPerfectAPI);
+    systemPrintf("Connecting to: %s\r\n", pointPerfectAPI);
 
     HTTPClient http;
     http.begin(client, pointPerfectAPI);
@@ -232,8 +232,8 @@ bool pointperfectProvisionDevice()
 
     if (httpResponseCode != 200)
     {
-      Serial.printf("HTTP response error %d: ", httpResponseCode);
-      Serial.println(response);
+      systemPrintf("HTTP response error %d: ", httpResponseCode);
+      systemPrintln(response);
       break;
     }
     else
@@ -243,13 +243,13 @@ bool pointperfectProvisionDevice()
       jsonZtp = new DynamicJsonDocument(4096);
       if (!jsonZtp)
       {
-        Serial.println("ERROR - Failed to allocate jsonZtp!\r\n");
+        systemPrintln("ERROR - Failed to allocate jsonZtp!\r\n");
         break;
       }
       DeserializationError error = deserializeJson(*jsonZtp, response);
       if (DeserializationError::Ok != error)
       {
-        Serial.println("JSON error");
+        systemPrintln("JSON error");
         break;
       }
       else
@@ -257,17 +257,17 @@ bool pointperfectProvisionDevice()
         tempHolder = (char *)malloc(2000);
         if (!tempHolder)
         {
-          Serial.println("ERROR - Failed to allocate tempHolder buffer!\r\n");
+          systemPrintln("ERROR - Failed to allocate tempHolder buffer!\r\n");
           break;
         }
         strcpy(tempHolder, (const char*)((*jsonZtp)["certificate"]));
-        //      Serial.printf("len of PrivateCert: %d\r\n", strlen(tempHolder));
-        //      Serial.printf("privateCert: %s\r\n", tempHolder);
+        //      systemPrintf("len of PrivateCert: %d\r\n", strlen(tempHolder));
+        //      systemPrintf("privateCert: %s\r\n", tempHolder);
         recordFile("certificate", tempHolder, strlen(tempHolder));
 
         strcpy(tempHolder, (const char*)((*jsonZtp)["privateKey"]));
-        //      Serial.printf("len of privateKey: %d\r\n", strlen(tempHolder));
-        //      Serial.printf("privateKey: %s\r\n", tempHolder);
+        //      systemPrintf("len of privateKey: %d\r\n", strlen(tempHolder));
+        //      systemPrintf("privateKey: %s\r\n", tempHolder);
         recordFile("privateKey", tempHolder, strlen(tempHolder));
 
         strcpy(settings.pointPerfectClientID, (const char*)((*jsonZtp)["clientId"]));
@@ -284,7 +284,7 @@ bool pointperfectProvisionDevice()
       }
     } //HTTP Response was 200
 
-    Serial.println("Device successfully provisioned. Keys obtained.");
+    systemPrintln("Device successfully provisioned. Keys obtained.");
 
     recordSystemSettings();
     retVal = true;
@@ -322,7 +322,7 @@ bool pointperfectUpdateKeys()
     keyContents = (char*)malloc(CONTENT_SIZE);
     if ((!certificateContents) || (!keyContents))
     {
-      Serial.println("Failed to allocate content buffers!");
+      systemPrintln("Failed to allocate content buffers!");
       break;
     }
 
@@ -349,13 +349,13 @@ bool pointperfectUpdateKeys()
     int maxTries = 3;
     do
     {
-      Serial.print("MQTT connecting...");
+      systemPrint("MQTT connecting...");
 
       //Attempt to the key broker
       if (mqttClient.connect(settings.pointPerfectClientID))
       {
         //Successful connection
-        Serial.println("connected");
+        systemPrintln("connected");
         //mqttClient.subscribe(settings.pointPerfectLBandTopic); //The /pp/key/Lb channel fails to respond with keys
         mqttClient.subscribe("/pp/ubx/0236/Lb"); //Alternate channel for L-Band keys
         break;
@@ -364,7 +364,7 @@ bool pointperfectUpdateKeys()
       //Retry the connection attempt
       if (--maxTries)
       {
-        Serial.print(".");
+        systemPrint(".");
         log_d("failed, status code: %d try again in 1 second", mqttClient.state());
         delay(1000);
       }
@@ -373,12 +373,12 @@ bool pointperfectUpdateKeys()
     //Check for connection failure
     if (mqttClient.connected() == false)
     {
-      Serial.println("failed!");
+      systemPrintln("failed!");
       log_d("MQTT failed to connect");
       break;
     }
 
-    Serial.print("Waiting for keys");
+    systemPrint("Waiting for keys");
 
     //Wait for callback
     startTime = millis();
@@ -400,14 +400,14 @@ bool pointperfectUpdateKeys()
 
       //Continue waiting for the keys
       delay(100);
-      Serial.print(".");
+      systemPrint(".");
     }
-    Serial.println();
+    systemPrintln();
 
     //Determine if the keys were updated
     if (mqttMessageReceived)
     {
-      Serial.println("Keys successfully updated");
+      systemPrintln("Keys successfully updated");
       gotKeys = true;
     }
 
@@ -471,22 +471,22 @@ void mqttCallback(char* topic, byte* message, unsigned int length)
       strcat(settings.pointPerfectNextKey, temp);
     }
 
-    //    Serial.println();
+    //    systemPrintln();
 
-    //    Serial.printf("pointPerfectCurrentKeyStart: %lld\r\n", settings.pointPerfectCurrentKeyStart);
-    //    Serial.printf("pointPerfectCurrentKeyDuration: %lld\r\n", settings.pointPerfectCurrentKeyDuration);
-    //    Serial.printf("pointPerfectNextKeyStart: %lld\r\n", settings.pointPerfectNextKeyStart);
-    //    Serial.printf("pointPerfectNextKeyDuration: %lld\r\n", settings.pointPerfectNextKeyDuration);
+    //    systemPrintf("pointPerfectCurrentKeyStart: %lld\r\n", settings.pointPerfectCurrentKeyStart);
+    //    systemPrintf("pointPerfectCurrentKeyDuration: %lld\r\n", settings.pointPerfectCurrentKeyDuration);
+    //    systemPrintf("pointPerfectNextKeyStart: %lld\r\n", settings.pointPerfectNextKeyStart);
+    //    systemPrintf("pointPerfectNextKeyDuration: %lld\r\n", settings.pointPerfectNextKeyDuration);
     //
-    //    Serial.printf("currentWeek: %d\r\n", currentWeek);
-    //    Serial.printf("currentToW: %d\r\n", currentToW);
-    //    Serial.print("Current key: ");
-    //    Serial.println(settings.pointPerfectCurrentKey);
+    //    systemPrintf("currentWeek: %d\r\n", currentWeek);
+    //    systemPrintf("currentToW: %d\r\n", currentToW);
+    //    systemPrint("Current key: ");
+    //    systemPrintln(settings.pointPerfectCurrentKey);
     //
-    //    Serial.printf("nextWeek: %d\r\n", nextWeek);
-    //    Serial.printf("nextToW: %d\r\n", nextToW);
-    //    Serial.print("nextKey key: ");
-    //    Serial.println(settings.pointPerfectNextKey);
+    //    systemPrintf("nextWeek: %d\r\n", nextWeek);
+    //    systemPrintf("nextToW: %d\r\n", nextToW);
+    //    systemPrint("nextKey key: ");
+    //    systemPrintln(settings.pointPerfectNextKey);
 
     //Convert from ToW and Week to key duration and key start
     WeekToWToUnixEpoch(&settings.pointPerfectCurrentKeyStart, currentWeek, currentToW);
@@ -501,10 +501,10 @@ void mqttCallback(char* topic, byte* message, unsigned int length)
     settings.pointPerfectCurrentKeyDuration = settings.pointPerfectNextKeyStart - settings.pointPerfectCurrentKeyStart - 1;
     settings.pointPerfectNextKeyDuration = settings.pointPerfectCurrentKeyDuration; //We assume next key duration is the same as current key duration because we have to
 
-    //    Serial.printf("pointPerfectCurrentKeyStart: %lld\r\n", settings.pointPerfectCurrentKeyStart);
-    //    Serial.printf("pointPerfectCurrentKeyDuration: %lld\r\n", settings.pointPerfectCurrentKeyDuration);
-    //    Serial.printf("pointPerfectNextKeyStart: %lld\r\n", settings.pointPerfectNextKeyStart);
-    //    Serial.printf("pointPerfectNextKeyDuration: %lld\r\n", settings.pointPerfectNextKeyDuration);
+    //    systemPrintf("pointPerfectCurrentKeyStart: %lld\r\n", settings.pointPerfectCurrentKeyStart);
+    //    systemPrintf("pointPerfectCurrentKeyDuration: %lld\r\n", settings.pointPerfectCurrentKeyDuration);
+    //    systemPrintf("pointPerfectNextKeyStart: %lld\r\n", settings.pointPerfectNextKeyStart);
+    //    systemPrintf("pointPerfectNextKeyDuration: %lld\r\n", settings.pointPerfectNextKeyDuration);
   }
 
   mqttMessageReceived = true;
@@ -515,13 +515,13 @@ void mqttCallback(char* topic, byte* message, unsigned int length)
 //https://www.includehelp.com/c-programs/validate-date.aspx
 bool getDate(uint8_t &dd, uint8_t &mm, uint16_t &yy)
 {
-  Serial.print("Enter Day: ");
+  systemPrint("Enter Day: ");
   dd = getNumber(); //Returns EXIT, TIMEOUT, or long
 
-  Serial.print("Enter Month: ");
+  systemPrint("Enter Month: ");
   mm = getNumber(); //Returns EXIT, TIMEOUT, or long
 
-  Serial.print("Enter Year (YYYY): ");
+  systemPrint("Enter Year (YYYY): ");
   yy = getNumber(); //Returns EXIT, TIMEOUT, or long
 
   //check year
@@ -673,16 +673,16 @@ void dateToKeyStartDuration(uint8_t expDay, uint8_t expMonth, uint16_t expYear, 
   *settingsKeyStart = startUnixEpoch * 1000L; //Convert to ms
   *settingsKeyDuration = (28 * 24 * 60 * 60 * 1000LL) - 1; //We assume keys last for 28 days (minus one ms to be before midnight)
 
-  Serial.printf("  KeyStart: %lld\r\n", *settingsKeyStart);
-  Serial.printf("  KeyDuration: %lld\r\n", *settingsKeyDuration);
+  systemPrintf("  KeyStart: %lld\r\n", *settingsKeyStart);
+  systemPrintf("  KeyDuration: %lld\r\n", *settingsKeyDuration);
 
   //Print ToW and Week for debugging
   uint16_t keyGPSWeek;
   uint32_t keyGPSToW;
   long long unixEpoch = thingstreamEpochToGPSEpoch(*settingsKeyStart, *settingsKeyDuration);
   unixEpochToWeekToW(unixEpoch, &keyGPSWeek, &keyGPSToW);
-  Serial.printf("  keyGPSWeek: %d\r\n", keyGPSWeek);
-  Serial.printf("  keyGPSToW: %d\r\n", keyGPSToW);
+  systemPrintf("  keyGPSWeek: %d\r\n", keyGPSWeek);
+  systemPrintf("  keyGPSToW: %d\r\n", keyGPSToW);
 }
 
 /*
@@ -763,12 +763,12 @@ void pointperfectApplyKeys()
     //NEO-D9S encrypted PMP messages are only supported on ZED-F9P firmware v1.30 and above
     if (zedModuleType != PLATFORM_F9P)
     {
-      Serial.println("Error: PointPerfect corrections currently only supported on the ZED-F9P.");
+      systemPrintln("Error: PointPerfect corrections currently only supported on the ZED-F9P.");
       return;
     }
     if (zedFirmwareVersionInt < 130)
     {
-      Serial.println("Error: PointPerfect corrections currently supported by ZED-F9P firmware v1.30 and above. Please upgrade your ZED firmware: https://learn.sparkfun.com/tutorials/how-to-upgrade-firmware-of-a-u-blox-gnss-receiver");
+      systemPrintln("Error: PointPerfect corrections currently supported by ZED-F9P firmware v1.30 and above. Please upgrade your ZED firmware: https://learn.sparkfun.com/tutorials/how-to-upgrade-firmware-of-a-u-blox-gnss-receiver");
       return;
     }
 
@@ -798,7 +798,7 @@ void pointperfectApplyKeys()
                         nextKeyLengthBytes, nextKeyGPSWeek, nextKeyGPSToW, settings.pointPerfectNextKey);
 
       if (response == false)
-        Serial.println("setDynamicSPARTNKeys failed");
+        systemPrintln("setDynamicSPARTNKeys failed");
       else
       {
         log_d("PointPerfect keys applied");
@@ -880,7 +880,7 @@ void beginLBand()
     }
     else
     {
-      Serial.println("Error: Unknown band area. Defaulting to US band.");
+      systemPrintln("Error: Unknown band area. Defaulting to US band.");
       settings.LBandFreq = 1556290000; //Default to US
     }
     recordSystemSettings();
@@ -906,7 +906,7 @@ void beginLBand()
   response &= i2cLBand.setVal32(UBLOX_CFG_UART2_BAUDRATE,         38400); // match baudrate with ZED default
 
   if (response == false)
-    Serial.println("L-Band failed to configure");
+    systemPrintln("L-Band failed to configure");
 
   i2cLBand.softwareResetGNSSOnly(); // Do a restart
 
@@ -928,44 +928,44 @@ void menuPointPerfect()
 #ifdef COMPILE_L_BAND
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: PointPerfect Corrections");
+    systemPrintln();
+    systemPrintln("Menu: PointPerfect Corrections");
 
     char hardwareID[13];
     sprintf(hardwareID, "%02X%02X%02X%02X%02X%02X", lbandMACAddress[0], lbandMACAddress[1], lbandMACAddress[2], lbandMACAddress[3], lbandMACAddress[4], lbandMACAddress[5]); //Get ready for JSON
-    Serial.printf("Device ID: %s\r\n", hardwareID);
+    systemPrintf("Device ID: %s\r\n", hardwareID);
 
-    Serial.print("Days until keys expire: ");
+    systemPrint("Days until keys expire: ");
     if (strlen(settings.pointPerfectCurrentKey) > 0)
     {
       uint8_t daysRemaining = daysFromEpoch(settings.pointPerfectNextKeyStart + settings.pointPerfectNextKeyDuration + 1);
-      Serial.println(daysRemaining);
+      systemPrintln(daysRemaining);
     }
     else
-      Serial.println("No keys");
+      systemPrintln("No keys");
 
-    Serial.print("1) Use PointPerfect Corrections: ");
-    if (settings.enablePointPerfectCorrections == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("1) Use PointPerfect Corrections: ");
+    if (settings.enablePointPerfectCorrections == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("2) Set Home WiFi SSID: ");
-    Serial.println(settings.home_wifiSSID);
+    systemPrint("2) Set Home WiFi SSID: ");
+    systemPrintln(settings.home_wifiSSID);
 
-    Serial.print("3) Set Home WiFi PW: ");
-    Serial.println(settings.home_wifiPW);
+    systemPrint("3) Set Home WiFi PW: ");
+    systemPrintln(settings.home_wifiPW);
 
-    Serial.print("4) Toggle Auto Key Renewal: ");
-    if (settings.autoKeyRenewal == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("4) Toggle Auto Key Renewal: ");
+    if (settings.autoKeyRenewal == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
     if (strlen(settings.pointPerfectCurrentKey) == 0 || strlen(settings.pointPerfectLBandTopic) == 0)
-      Serial.println("5) Provision Device");
+      systemPrintln("5) Provision Device");
     else
-      Serial.println("5) Update Keys");
+      systemPrintln("5) Update Keys");
 
-    Serial.println("k) Manual Key Entry");
+    systemPrintln("k) Manual Key Entry");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     byte incoming = getCharacterNumber();
 
@@ -975,12 +975,12 @@ void menuPointPerfect()
     }
     else if (incoming == 2)
     {
-      Serial.print("Enter Home WiFi SSID: ");
+      systemPrint("Enter Home WiFi SSID: ");
       getString(settings.home_wifiSSID, sizeof(settings.home_wifiSSID));
     }
     else if (incoming == 3)
     {
-      Serial.printf("Enter password for Home WiFi network %s: ", settings.home_wifiSSID);
+      systemPrintf("Enter password for Home WiFi network %s: ", settings.home_wifiSSID);
       getString(settings.home_wifiPW, sizeof(settings.home_wifiPW));
     }
     else if (incoming == 4)
@@ -992,7 +992,7 @@ void menuPointPerfect()
 #ifdef COMPILE_WIFI
       if (strlen(settings.home_wifiSSID) == 0)
       {
-        Serial.println("Error: Please enter SSID before getting keys");
+        systemPrintln("Error: Please enter SSID before getting keys");
       }
       else
       {
@@ -1002,10 +1002,10 @@ void menuPointPerfect()
         while (wifiGetStatus() != WL_CONNECTED)
         {
           delay(500);
-          Serial.print(".");
+          systemPrint(".");
           if (millis() - startTime > 15000)
           {
-            Serial.println("Error: No WiFi available");
+            systemPrintln("Error: No WiFi available");
             break;
           }
         }
@@ -1013,9 +1013,9 @@ void menuPointPerfect()
         if (wifiGetStatus() == WL_CONNECTED)
         {
 
-          Serial.println();
-          Serial.print("WiFi connected: ");
-          Serial.println(wifiGetIpAddress());
+          systemPrintln();
+          systemPrint("WiFi connected: ");
+          systemPrintln(wifiGetIpAddress());
 
           //Check if we have certificates
           char fileName[80];

--- a/Firmware/RTK_Surveyor/menuPorts.ino
+++ b/Firmware/RTK_Surveyor/menuPorts.ino
@@ -11,24 +11,24 @@ void menuPortsSurveyor()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Ports");
+    systemPrintln();
+    systemPrintln("Menu: Ports");
 
-    Serial.print("1) Set serial baud rate for Radio Port: ");
-    Serial.print(i2cGNSS.getVal32(UBLOX_CFG_UART2_BAUDRATE));
-    Serial.println(" bps");
+    systemPrint("1) Set serial baud rate for Radio Port: ");
+    systemPrint(i2cGNSS.getVal32(UBLOX_CFG_UART2_BAUDRATE));
+    systemPrintln(" bps");
 
-    Serial.print("2) Set serial baud rate for Data Port: ");
-    Serial.print(i2cGNSS.getVal32(UBLOX_CFG_UART1_BAUDRATE));
-    Serial.println(" bps");
+    systemPrint("2) Set serial baud rate for Data Port: ");
+    systemPrint(i2cGNSS.getVal32(UBLOX_CFG_UART1_BAUDRATE));
+    systemPrintln(" bps");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
     if (incoming == 1)
     {
-      Serial.print("Enter baud rate (4800 to 921600) for Radio Port: ");
+      systemPrint("Enter baud rate (4800 to 921600) for Radio Port: ");
       int newBaud = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((newBaud != INPUT_RESPONSE_GETNUMBER_EXIT) && (newBaud != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
@@ -49,13 +49,13 @@ void menuPortsSurveyor()
         }
         else
         {
-          Serial.println("Error: Baud rate out of range");
+          systemPrintln("Error: Baud rate out of range");
         }
       }
     }
     else if (incoming == 2)
     {
-      Serial.print("Enter baud rate (4800 to 921600) for Data Port: ");
+      systemPrint("Enter baud rate (4800 to 921600) for Data Port: ");
       int newBaud = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((newBaud != INPUT_RESPONSE_GETNUMBER_EXIT) && (newBaud != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
@@ -76,7 +76,7 @@ void menuPortsSurveyor()
         }
         else
         {
-          Serial.println("Error: Baud rate out of range");
+          systemPrintln("Error: Baud rate out of range");
         }
       }
     }
@@ -99,47 +99,47 @@ void menuPortsMultiplexed()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Ports");
+    systemPrintln();
+    systemPrintln("Menu: Ports");
 
-    Serial.print("1) Set Radio port serial baud rate: ");
-    Serial.print(i2cGNSS.getVal32(UBLOX_CFG_UART2_BAUDRATE));
-    Serial.println(" bps");
+    systemPrint("1) Set Radio port serial baud rate: ");
+    systemPrint(i2cGNSS.getVal32(UBLOX_CFG_UART2_BAUDRATE));
+    systemPrintln(" bps");
 
-    Serial.print("2) Set Data port connections: ");
+    systemPrint("2) Set Data port connections: ");
     if (settings.dataPortChannel == MUX_UBLOX_NMEA)
-      Serial.println("NMEA TX Out/RX In");
+      systemPrintln("NMEA TX Out/RX In");
     else if (settings.dataPortChannel == MUX_PPS_EVENTTRIGGER)
-      Serial.println("PPS OUT/Event Trigger In");
+      systemPrintln("PPS OUT/Event Trigger In");
     else if (settings.dataPortChannel == MUX_I2C_WT)
     {
       if (zedModuleType == PLATFORM_F9P)
-        Serial.println("I2C SDA/SCL");
+        systemPrintln("I2C SDA/SCL");
       else if (zedModuleType == PLATFORM_F9R)
-        Serial.println("Wheel Tick/Direction");
+        systemPrintln("Wheel Tick/Direction");
     }
     else if (settings.dataPortChannel == MUX_ADC_DAC)
-      Serial.println("ESP32 DAC Out/ADC In");
+      systemPrintln("ESP32 DAC Out/ADC In");
 
 
     if (settings.dataPortChannel == MUX_UBLOX_NMEA)
     {
-      Serial.print("3) Set Data port serial baud rate: ");
-      Serial.print(i2cGNSS.getVal32(UBLOX_CFG_UART1_BAUDRATE));
-      Serial.println(" bps");
+      systemPrint("3) Set Data port serial baud rate: ");
+      systemPrint(i2cGNSS.getVal32(UBLOX_CFG_UART1_BAUDRATE));
+      systemPrintln(" bps");
     }
     else if (settings.dataPortChannel == MUX_PPS_EVENTTRIGGER)
     {
-      Serial.println("3) Configure External Triggers");
+      systemPrintln("3) Configure External Triggers");
     }
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
     if (incoming == 1)
     {
-      Serial.print("Enter baud rate (4800 to 921600) for Radio Port: ");
+      systemPrint("Enter baud rate (4800 to 921600) for Radio Port: ");
       int newBaud = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((newBaud != INPUT_RESPONSE_GETNUMBER_EXIT) && (newBaud != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
@@ -160,25 +160,25 @@ void menuPortsMultiplexed()
         }
         else
         {
-          Serial.println("Error: Baud rate out of range");
+          systemPrintln("Error: Baud rate out of range");
         }
       }
     }
     else if (incoming == 2)
     {
-      Serial.println("\n\rEnter the pin connection to use (1 to 4) for Data Port: ");
-      Serial.println("1) NMEA TX Out/RX In");
-      Serial.println("2) PPS OUT/Event Trigger In");
+      systemPrintln("\n\rEnter the pin connection to use (1 to 4) for Data Port: ");
+      systemPrintln("1) NMEA TX Out/RX In");
+      systemPrintln("2) PPS OUT/Event Trigger In");
       if (zedModuleType == PLATFORM_F9P)
-        Serial.println("3) I2C SDA/SCL");
+        systemPrintln("3) I2C SDA/SCL");
       else if (zedModuleType == PLATFORM_F9R)
-        Serial.println("3) Wheel Tick/Direction");
-      Serial.println("4) ESP32 DAC Out/ADC In");
+        systemPrintln("3) Wheel Tick/Direction");
+      systemPrintln("4) ESP32 DAC Out/ADC In");
 
       int muxPort = getNumber(); //Returns EXIT, TIMEOUT, or long
       if (muxPort < 1 || muxPort > 4)
       {
-        Serial.println("Error: Pin connection out of range");
+        systemPrintln("Error: Pin connection out of range");
       }
       else
       {
@@ -188,7 +188,7 @@ void menuPortsMultiplexed()
     }
     else if (incoming == 3 && settings.dataPortChannel == MUX_UBLOX_NMEA)
     {
-      Serial.print("Enter baud rate (4800 to 921600) for Data Port: ");
+      systemPrint("Enter baud rate (4800 to 921600) for Data Port: ");
       int newBaud = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((newBaud != INPUT_RESPONSE_GETNUMBER_EXIT) && (newBaud != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
@@ -209,7 +209,7 @@ void menuPortsMultiplexed()
         }
         else
         {
-          Serial.println("Error: Baud rate out of range");
+          systemPrintln("Error: Baud rate out of range");
         }
       }
     }
@@ -237,33 +237,33 @@ void menuPortHardwareTriggers()
   bool updateSettings = false;
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Port Hardware Trigger");
+    systemPrintln();
+    systemPrintln("Menu: Port Hardware Trigger");
 
-    Serial.print("1) Enable External Pulse: ");
-    if (settings.enableExternalPulse == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("1) Enable External Pulse: ");
+    if (settings.enableExternalPulse == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
     if (settings.enableExternalPulse == true)
     {
-      Serial.print("2) Set time between pulses: ");
-      Serial.print(settings.externalPulseTimeBetweenPulse_us / 1000.0, 0);
-      Serial.println("ms");
+      systemPrint("2) Set time between pulses: ");
+      systemPrint(settings.externalPulseTimeBetweenPulse_us / 1000.0, 0);
+      systemPrintln("ms");
 
-      Serial.print("3) Set pulse length: ");
-      Serial.print(settings.externalPulseLength_us / 1000.0, 0);
-      Serial.println("ms");
+      systemPrint("3) Set pulse length: ");
+      systemPrint(settings.externalPulseLength_us / 1000.0, 0);
+      systemPrintln("ms");
 
-      Serial.print("4) Set pulse polarity: ");
-      if (settings.externalPulsePolarity == PULSE_RISING_EDGE) Serial.println("Rising");
-      else Serial.println("Falling");
+      systemPrint("4) Set pulse polarity: ");
+      if (settings.externalPulsePolarity == PULSE_RISING_EDGE) systemPrintln("Rising");
+      else systemPrintln("Falling");
     }
 
-    Serial.print("5) Log External Events: ");
-    if (settings.enableExternalHardwareEventLogging == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("5) Log External Events: ");
+    if (settings.enableExternalHardwareEventLogging == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     int incoming = getNumber(); //Returns EXIT, TIMEOUT, or long
 
@@ -274,13 +274,13 @@ void menuPortHardwareTriggers()
     }
     else if (incoming == 2 && settings.enableExternalPulse == true)
     {
-      Serial.print("Time between pulses in milliseconds: ");
+      systemPrint("Time between pulses in milliseconds: ");
       long pulseTime = getNumber(); //Returns EXIT, TIMEOUT, or long
 
       if (pulseTime != INPUT_RESPONSE_GETNUMBER_TIMEOUT && pulseTime != INPUT_RESPONSE_GETNUMBER_EXIT)
       {
         if (pulseTime < 1 || pulseTime > 60000) //60s max
-          Serial.println("Error: Time between pulses out of range");
+          systemPrintln("Error: Time between pulses out of range");
         else
         {
           settings.externalPulseTimeBetweenPulse_us = pulseTime * 1000;
@@ -295,13 +295,13 @@ void menuPortHardwareTriggers()
     }
     else if (incoming == 3 && settings.enableExternalPulse == true)
     {
-      Serial.print("Pulse length in milliseconds: ");
+      systemPrint("Pulse length in milliseconds: ");
       long pulseLength = getNumber(); //Returns EXIT, TIMEOUT, or long
 
       if (pulseLength != INPUT_RESPONSE_GETNUMBER_TIMEOUT && pulseLength != INPUT_RESPONSE_GETNUMBER_EXIT)
       {
         if (pulseLength > (settings.externalPulseTimeBetweenPulse_us / 1000)) //pulseLength must be shorter than pulseTime
-          Serial.println("Error: Pulse length must be shorter than time between pulses");
+          systemPrintln("Error: Pulse length must be shorter than time between pulses");
         else
         {
           settings.externalPulseLength_us = pulseLength * 1000;
@@ -347,7 +347,7 @@ void eventTriggerReceived(UBX_TIM_TM2_data_t ubxDataStruct)
   // The falling edge is less useful, as it will be "debounced" by the loop code
   if (ubxDataStruct.flags.bits.newRisingEdge) // 1 if a new rising edge was detected
   {
-    Serial.println("Rising Edge Event");
+    systemPrintln("Rising Edge Event");
 
     triggerCount = ubxDataStruct.count;
     triggerTowMsR = ubxDataStruct.towMsR; // Time Of Week of rising edge (ms)

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -5,63 +5,63 @@ void menuSystem()
 
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: System");
+    systemPrintln();
+    systemPrintln("Menu: System");
 
     beginI2C();
     if (online.i2c == false)
-      Serial.println("I2C: Offline - Something is causing bus problems");
+      systemPrintln("I2C: Offline - Something is causing bus problems");
 
-    Serial.print("GNSS: ");
+    systemPrint("GNSS: ");
     if (online.gnss == true)
     {
-      Serial.print("Online - ");
+      systemPrint("Online - ");
 
       printZEDInfo();
 
       printCurrentConditions();
     }
-    else Serial.println("Offline");
+    else systemPrintln("Offline");
 
-    Serial.print("Display: ");
-    if (online.display == true) Serial.println("Online");
-    else Serial.println("Offline");
+    systemPrint("Display: ");
+    if (online.display == true) systemPrintln("Online");
+    else systemPrintln("Offline");
 
-    Serial.print("Accelerometer: ");
-    if (online.display == true) Serial.println("Online");
-    else Serial.println("Offline");
+    systemPrint("Accelerometer: ");
+    if (online.display == true) systemPrintln("Online");
+    else systemPrintln("Offline");
 
-    Serial.print("Fuel Gauge: ");
+    systemPrint("Fuel Gauge: ");
     if (online.battery == true)
     {
-      Serial.print("Online - ");
+      systemPrint("Online - ");
 
       battLevel = lipo.getSOC();
       battVoltage = lipo.getVoltage();
       battChangeRate = lipo.getChangeRate();
 
-      Serial.printf("Batt (%d%%) / Voltage: %0.02fV", battLevel, battVoltage);
-      Serial.println();
+      systemPrintf("Batt (%d%%) / Voltage: %0.02fV", battLevel, battVoltage);
+      systemPrintln();
     }
-    else Serial.println("Offline");
+    else systemPrintln("Offline");
 
-    Serial.print("microSD: ");
-    if (online.microSD == true) Serial.println("Online");
-    else Serial.println("Offline");
+    systemPrint("microSD: ");
+    if (online.microSD == true) systemPrintln("Online");
+    else systemPrintln("Offline");
 
     if (online.lband == true)
     {
-      Serial.print("L-Band: Online - ");
+      systemPrint("L-Band: Online - ");
 
-      if (online.lbandCorrections == true) Serial.print("Keys Good");
-      else Serial.print("No Keys");
+      if (online.lbandCorrections == true) systemPrint("Keys Good");
+      else systemPrint("No Keys");
 
-      Serial.print(" / Corrections Received");
-      if (lbandCorrectionsReceived == false) Serial.print(" Failed");
+      systemPrint(" / Corrections Received");
+      if (lbandCorrectionsReceived == false) systemPrint(" Failed");
 
-      Serial.printf(" / Eb/N0[dB] (>9 is good): %0.2f", lBandEBNO);
+      systemPrintf(" / Eb/N0[dB] (>9 is good): %0.2f", lBandEBNO);
 
-      Serial.print(" - ");
+      systemPrint(" - ");
 
       printNEOInfo();
     }
@@ -70,8 +70,8 @@ void menuSystem()
     bluetoothTest(false);
 
 #ifdef COMPILE_WIFI
-    Serial.print("WiFi MAC Address: ");
-    Serial.printf("%02X:%02X:%02X:%02X:%02X:%02X\r\n", wifiMACAddress[0],
+    systemPrint("WiFi MAC Address: ");
+    systemPrintf("%02X:%02X:%02X:%02X:%02X:%02X\r\n", wifiMACAddress[0],
                   wifiMACAddress[1], wifiMACAddress[2], wifiMACAddress[3],
                   wifiMACAddress[4], wifiMACAddress[5]);
     if (wifiState == WIFI_CONNECTED)
@@ -97,8 +97,8 @@ void menuSystem()
     uptimeSeconds = uptimeMilliseconds / MILLISECONDS_IN_A_SECOND;
     uptimeMilliseconds %= MILLISECONDS_IN_A_SECOND;
 
-    Serial.print("System Uptime: ");
-    Serial.printf("%d %02d:%02d:%02d.%03lld (Resets: %d)\r\n",
+    systemPrint("System Uptime: ");
+    systemPrintf("%d %02d:%02d:%02d.%03lld (Resets: %d)\r\n",
                   uptimeDays,
                   uptimeHours,
                   uptimeMinutes,
@@ -109,26 +109,26 @@ void menuSystem()
     //Display NTRIP Client status and uptime
     if (settings.enableNtripClient == true && (systemState >= STATE_ROVER_NOT_STARTED && systemState <= STATE_ROVER_RTK_FIX))
     {
-      Serial.print("NTRIP Client ");
+      systemPrint("NTRIP Client ");
       switch (ntripClientState)
       {
         case NTRIP_CLIENT_OFF:
-          Serial.print("Disconnected");
+          systemPrint("Disconnected");
           break;
         case NTRIP_CLIENT_ON:
         case NTRIP_CLIENT_WIFI_CONNECTING:
         case NTRIP_CLIENT_WIFI_CONNECTED:
         case NTRIP_CLIENT_CONNECTING:
-          Serial.print("Connecting");
+          systemPrint("Connecting");
           break;
         case NTRIP_CLIENT_CONNECTED:
-          Serial.print("Connected");
+          systemPrint("Connected");
           break;
         default:
-          Serial.printf("Unknown: %d", ntripClientState);
+          systemPrintf("Unknown: %d", ntripClientState);
           break;
       }
-      Serial.printf(" - %s/%s:%d", settings.ntripClient_CasterHost, settings.ntripClient_MountPoint, settings.ntripClient_CasterPort);
+      systemPrintf(" - %s/%s:%d", settings.ntripClient_CasterHost, settings.ntripClient_MountPoint, settings.ntripClient_CasterPort);
 
       uptimeMilliseconds = ntripClientTimer - ntripClientStartTime;
 
@@ -144,8 +144,8 @@ void menuSystem()
       uptimeSeconds = uptimeMilliseconds / MILLISECONDS_IN_A_SECOND;
       uptimeMilliseconds %= MILLISECONDS_IN_A_SECOND;
 
-      Serial.print(" Uptime: ");
-      Serial.printf("%d %02d:%02d:%02d.%03lld (Reconnects: %d)\r\n",
+      systemPrint(" Uptime: ");
+      systemPrintf("%d %02d:%02d:%02d.%03lld (Reconnects: %d)\r\n",
                     uptimeDays,
                     uptimeHours,
                     uptimeMinutes,
@@ -157,11 +157,11 @@ void menuSystem()
     //Display NTRIP Server status and uptime
     if (settings.enableNtripServer == true && (systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING))
     {
-      Serial.print("NTRIP Server ");
+      systemPrint("NTRIP Server ");
       switch (ntripServerState)
       {
         case NTRIP_SERVER_OFF:
-          Serial.print("Disconnected");
+          systemPrint("Disconnected");
           break;
         case NTRIP_SERVER_ON:
         case NTRIP_SERVER_WIFI_CONNECTING:
@@ -169,16 +169,16 @@ void menuSystem()
         case NTRIP_SERVER_WAIT_GNSS_DATA:
         case NTRIP_SERVER_CONNECTING:
         case NTRIP_SERVER_AUTHORIZATION:
-          Serial.print("Connecting");
+          systemPrint("Connecting");
           break;
         case NTRIP_SERVER_CASTING:
-          Serial.print("Connected");
+          systemPrint("Connected");
           break;
         default:
-          Serial.printf("Unknown: %d", ntripServerState);
+          systemPrintf("Unknown: %d", ntripServerState);
           break;
       }
-      Serial.printf(" - %s/%s:%d", settings.ntripServer_CasterHost, settings.ntripServer_MountPoint, settings.ntripServer_CasterPort);
+      systemPrintf(" - %s/%s:%d", settings.ntripServer_CasterHost, settings.ntripServer_MountPoint, settings.ntripServer_CasterPort);
 
       uptimeMilliseconds = ntripServerTimer - ntripServerStartTime;
 
@@ -194,8 +194,8 @@ void menuSystem()
       uptimeSeconds = uptimeMilliseconds / MILLISECONDS_IN_A_SECOND;
       uptimeMilliseconds %= MILLISECONDS_IN_A_SECOND;
 
-      Serial.print(" Uptime: ");
-      Serial.printf("%d %02d:%02d:%02d.%03lld (Reconnects: %d)\r\n",
+      systemPrint(" Uptime: ");
+      systemPrintf("%d %02d:%02d:%02d.%03lld (Reconnects: %d)\r\n",
                     uptimeDays,
                     uptimeHours,
                     uptimeMinutes,
@@ -206,46 +206,46 @@ void menuSystem()
 
     if (settings.enableSD == true && online.microSD == true)
     {
-      Serial.println("f) Display microSD Files");
+      systemPrintln("f) Display microSD Files");
     }
 
-    Serial.print("e) Echo User Input: ");
-    if (settings.echoUserInput == true) Serial.println("On");
-    else Serial.println("Off");
+    systemPrint("e) Echo User Input: ");
+    if (settings.echoUserInput == true) systemPrintln("On");
+    else systemPrintln("Off");
 
-    Serial.println("d) Configure Debug");
+    systemPrintln("d) Configure Debug");
 
-    Serial.printf("z) Set time zone offset: %02d:%02d:%02d\r\n", settings.timeZoneHours, settings.timeZoneMinutes, settings.timeZoneSeconds);
+    systemPrintf("z) Set time zone offset: %02d:%02d:%02d\r\n", settings.timeZoneHours, settings.timeZoneMinutes, settings.timeZoneSeconds);
 
-    Serial.print("b) Set Bluetooth Mode: ");
+    systemPrint("b) Set Bluetooth Mode: ");
     if (settings.bluetoothRadioType == BLUETOOTH_RADIO_SPP)
-      Serial.println("Classic");
+      systemPrintln("Classic");
     else if (settings.bluetoothRadioType == BLUETOOTH_RADIO_BLE)
-      Serial.println("BLE");
+      systemPrintln("BLE");
     else
-      Serial.println("Off");
+      systemPrintln("Off");
 
-    Serial.print("c) Enable/disable WiFi TCP client (connect to phone): ");
+    systemPrint("c) Enable/disable WiFi TCP client (connect to phone): ");
     if (settings.enableTcpClient == true)
-      Serial.println("Enabled");
+      systemPrintln("Enabled");
     else
-      Serial.println("Disabled");
+      systemPrintln("Disabled");
 
-    Serial.print("n) Enable/disable WiFi TCP server: ");
+    systemPrint("n) Enable/disable WiFi TCP server: ");
     if (settings.enableTcpServer == true)
-      Serial.println("Enabled");
+      systemPrintln("Enabled");
     else
-      Serial.println("Disabled");
+      systemPrintln("Disabled");
 
-    Serial.println("r) Reset all settings to default");
+    systemPrintln("r) Reset all settings to default");
 
     // Support mode switching
-    Serial.println("B) Switch to Base mode");
-    Serial.println("R) Switch to Rover mode");
-    Serial.println("W) Switch to WiFi Config mode");
-    Serial.println("S) Shut down");
+    systemPrintln("B) Switch to Base mode");
+    systemPrintln("R) Switch to Rover mode");
+    systemPrintln("W) Switch to WiFi Config mode");
+    systemPrintln("S) Shut down");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     byte incoming = getCharacterNumber();
 
@@ -253,32 +253,32 @@ void menuSystem()
       menuDebug();
     else if (incoming == 'z')
     {
-      Serial.print("Enter time zone hour offset (-23 <= offset <= 23): ");
+      systemPrint("Enter time zone hour offset (-23 <= offset <= 23): ");
       int value = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((value != INPUT_RESPONSE_GETNUMBER_EXIT) && (value != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (value < -23 || value > 23)
-          Serial.println("Error: -24 < hours < 24");
+          systemPrintln("Error: -24 < hours < 24");
         else
         {
           settings.timeZoneHours = value;
 
-          Serial.print("Enter time zone minute offset (-59 <= offset <= 59): ");
+          systemPrint("Enter time zone minute offset (-59 <= offset <= 59): ");
           int value = getNumber(); //Returns EXIT, TIMEOUT, or long
           if ((value != INPUT_RESPONSE_GETNUMBER_EXIT) && (value != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
           {
             if (value < -59 || value > 59)
-              Serial.println("Error: -60 < minutes < 60");
+              systemPrintln("Error: -60 < minutes < 60");
             else
             {
               settings.timeZoneMinutes = value;
 
-              Serial.print("Enter time zone second offset (-59 <= offset <= 59): ");
+              systemPrint("Enter time zone second offset (-59 <= offset <= 59): ");
               int value = getNumber(); //Returns EXIT, TIMEOUT, or long
               if ((value != INPUT_RESPONSE_GETNUMBER_EXIT) && (value != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
               {
                 if (value < -59 || value > 59)
-                  Serial.println("Error: -60 < seconds < 60");
+                  systemPrintln("Error: -60 < seconds < 60");
                 else
                 {
                   settings.timeZoneSeconds = value;
@@ -324,19 +324,19 @@ void menuSystem()
         //Wait for the UART2 tasks to close the TCP client connections
         while (wifiTcpServerActive())
           delay(5);
-        Serial.println("TCP Server offline");
+        systemPrintln("TCP Server offline");
       }
     }
     else if (incoming == 'r')
     {
-      Serial.println("\r\nResetting to factory defaults. Press 'y' to confirm:");
+      systemPrintln("\r\nResetting to factory defaults. Press 'y' to confirm:");
       byte bContinue = getCharacterNumber();
       if (bContinue == 'y')
       {
         factoryReset();
       }
       else
-        Serial.println("Reset aborted");
+        systemPrintln("Reset aborted");
     }
     else if ((incoming == 'f') && (settings.enableSD == true) &&  (online.microSD == true))
     {
@@ -346,7 +346,7 @@ void menuSystem()
 
       //Notify the user if the microSD card is not available
       if (!online.microSD)
-        Serial.println("microSD card not online!");
+        systemPrintln("microSD card not online!");
       else
       {
         //Attempt to write to file system. This avoids collisions with file writing from other functions like recordSystemSettingsToFile() and F9PSerialReadTask()
@@ -354,13 +354,13 @@ void menuSystem()
         {
           markSemaphore(FUNCTION_FILELIST);
 
-          Serial.println("Files found (date time size name):\r\n");
+          systemPrintln("Files found (date time size name):\r\n");
           sd->ls(LS_R | LS_DATE | LS_SIZE);
         }
         else
         {
           //Error failed to list the contents of the microSD card
-          Serial.printf("sdCardSemaphore failed to yield, menuSystem.ino line %d\r\n", __LINE__);
+          systemPrintf("sdCardSemaphore failed to yield, menuSystem.ino line %d\r\n", __LINE__);
         }
 
         //Release the SD card if not originally mounted
@@ -384,7 +384,7 @@ void menuSystem()
       changeState(STATE_WIFI_CONFIG_NOT_STARTED);
     }
     else if (incoming == 'S') {
-      Serial.println("Shutting down...");
+      systemPrintln("Shutting down...");
       forceDisplayUpdate = true;
       powerDown(true);
     }
@@ -406,129 +406,129 @@ void menuDebug()
 {
   while (1)
   {
-    Serial.println();
-    Serial.println("Menu: Debug");
+    systemPrintln();
+    systemPrintln("Menu: Debug");
 
-    Serial.printf("Filtered by parser: %d NMEA / %d RTCM / %d UBX\n\r",
+    systemPrintf("Filtered by parser: %d NMEA / %d RTCM / %d UBX\n\r",
                   failedParserMessages_NMEA,
                   failedParserMessages_RTCM,
                   failedParserMessages_UBX);
 
-    Serial.print("1) u-blox I2C Debugging Output: ");
-    if (settings.enableI2Cdebug == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("1) u-blox I2C Debugging Output: ");
+    if (settings.enableI2Cdebug == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("2) Heap Reporting: ");
-    if (settings.enableHeapReport == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("2) Heap Reporting: ");
+    if (settings.enableHeapReport == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("3) Task Highwater Reporting: ");
-    if (settings.enableTaskReports == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrint("3) Task Highwater Reporting: ");
+    if (settings.enableTaskReports == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("4) Set SPI/SD Interface Frequency: ");
-    Serial.print(settings.spiFrequency);
-    Serial.println(" MHz");
+    systemPrint("4) Set SPI/SD Interface Frequency: ");
+    systemPrint(settings.spiFrequency);
+    systemPrintln(" MHz");
 
-    Serial.print("5) Set SPP RX Buffer Size: ");
-    Serial.println(settings.sppRxQueueSize);
+    systemPrint("5) Set SPP RX Buffer Size: ");
+    systemPrintln(settings.sppRxQueueSize);
 
-    Serial.print("6) Set SPP TX Buffer Size: ");
-    Serial.println(settings.sppTxQueueSize);
+    systemPrint("6) Set SPP TX Buffer Size: ");
+    systemPrintln(settings.sppTxQueueSize);
 
-    Serial.printf("8) Display Reset Counter: %d - ", settings.resetCount);
-    if (settings.enableResetDisplay == true) Serial.println("Enabled");
-    else Serial.println("Disabled");
+    systemPrintf("8) Display Reset Counter: %d - ", settings.resetCount);
+    if (settings.enableResetDisplay == true) systemPrintln("Enabled");
+    else systemPrintln("Disabled");
 
-    Serial.print("9) GNSS Serial Timeout: ");
-    Serial.println(settings.serialTimeoutGNSS);
+    systemPrint("9) GNSS Serial Timeout: ");
+    systemPrintln(settings.serialTimeoutGNSS);
 
-    Serial.print("10) Periodically print WiFi IP Address: ");
-    Serial.printf("%s\r\n", settings.enablePrintWifiIpAddress ? "Enabled" : "Disabled");
+    systemPrint("10) Periodically print WiFi IP Address: ");
+    systemPrintf("%s\r\n", settings.enablePrintWifiIpAddress ? "Enabled" : "Disabled");
 
-    Serial.print("11) Periodically print state: ");
-    Serial.printf("%s\r\n", settings.enablePrintState ? "Enabled" : "Disabled");
+    systemPrint("11) Periodically print state: ");
+    systemPrintf("%s\r\n", settings.enablePrintState ? "Enabled" : "Disabled");
 
-    Serial.print("12) Periodically print WiFi state: ");
-    Serial.printf("%s\r\n", settings.enablePrintWifiState ? "Enabled" : "Disabled");
+    systemPrint("12) Periodically print WiFi state: ");
+    systemPrintf("%s\r\n", settings.enablePrintWifiState ? "Enabled" : "Disabled");
 
-    Serial.print("13) Periodically print NTRIP client state: ");
-    Serial.printf("%s\r\n", settings.enablePrintNtripClientState ? "Enabled" : "Disabled");
+    systemPrint("13) Periodically print NTRIP client state: ");
+    systemPrintf("%s\r\n", settings.enablePrintNtripClientState ? "Enabled" : "Disabled");
 
-    Serial.print("14) Periodically print NTRIP server state: ");
-    Serial.printf("%s\r\n", settings.enablePrintNtripServerState ? "Enabled" : "Disabled");
+    systemPrint("14) Periodically print NTRIP server state: ");
+    systemPrintf("%s\r\n", settings.enablePrintNtripServerState ? "Enabled" : "Disabled");
 
-    Serial.print("15) Periodically print position: ");
-    Serial.printf("%s\r\n", settings.enablePrintPosition ? "Enabled" : "Disabled");
+    systemPrint("15) Periodically print position: ");
+    systemPrintf("%s\r\n", settings.enablePrintPosition ? "Enabled" : "Disabled");
 
-    Serial.print("16) Periodically print CPU idle time: ");
-    Serial.printf("%s\r\n", settings.enablePrintIdleTime ? "Enabled" : "Disabled");
+    systemPrint("16) Periodically print CPU idle time: ");
+    systemPrintf("%s\r\n", settings.enablePrintIdleTime ? "Enabled" : "Disabled");
 
-    Serial.println("17) Mirror ZED-F9x's UART1 settings to USB");
+    systemPrintln("17) Mirror ZED-F9x's UART1 settings to USB");
 
-    Serial.print("18) Print battery status messages: ");
-    Serial.printf("%s\r\n", settings.enablePrintBatteryMessages ? "Enabled" : "Disabled");
+    systemPrint("18) Print battery status messages: ");
+    systemPrintf("%s\r\n", settings.enablePrintBatteryMessages ? "Enabled" : "Disabled");
 
-    Serial.print("19) Print Rover accuracy messages: ");
-    Serial.printf("%s\r\n", settings.enablePrintRoverAccuracy ? "Enabled" : "Disabled");
+    systemPrint("19) Print Rover accuracy messages: ");
+    systemPrintf("%s\r\n", settings.enablePrintRoverAccuracy ? "Enabled" : "Disabled");
 
-    Serial.print("20) Print messages with bad checksums or CRCs: ");
-    Serial.printf("%s\r\n", settings.enablePrintBadMessages ? "Enabled" : "Disabled");
+    systemPrint("20) Print messages with bad checksums or CRCs: ");
+    systemPrintf("%s\r\n", settings.enablePrintBadMessages ? "Enabled" : "Disabled");
 
-    Serial.print("21) Print log file messages: ");
-    Serial.printf("%s\r\n", settings.enablePrintLogFileMessages ? "Enabled" : "Disabled");
+    systemPrint("21) Print log file messages: ");
+    systemPrintf("%s\r\n", settings.enablePrintLogFileMessages ? "Enabled" : "Disabled");
 
-    Serial.print("22) Print log file status: ");
-    Serial.printf("%s\r\n", settings.enablePrintLogFileStatus ? "Enabled" : "Disabled");
+    systemPrint("22) Print log file status: ");
+    systemPrintf("%s\r\n", settings.enablePrintLogFileStatus ? "Enabled" : "Disabled");
 
-    Serial.print("23) Print ring buffer offsets: ");
-    Serial.printf("%s\r\n", settings.enablePrintRingBufferOffsets ? "Enabled" : "Disabled");
+    systemPrint("23) Print ring buffer offsets: ");
+    systemPrintf("%s\r\n", settings.enablePrintRingBufferOffsets ? "Enabled" : "Disabled");
 
-    Serial.print("24) Print GNSS --> NTRIP caster messages: ");
-    Serial.printf("%s\r\n", settings.enablePrintNtripServerRtcm ? "Enabled" : "Disabled");
+    systemPrint("24) Print GNSS --> NTRIP caster messages: ");
+    systemPrintf("%s\r\n", settings.enablePrintNtripServerRtcm ? "Enabled" : "Disabled");
 
-    Serial.print("25) Print NTRIP caster --> GNSS messages: ");
-    Serial.printf("%s\r\n", settings.enablePrintNtripClientRtcm ? "Enabled" : "Disabled");
+    systemPrint("25) Print NTRIP caster --> GNSS messages: ");
+    systemPrintf("%s\r\n", settings.enablePrintNtripClientRtcm ? "Enabled" : "Disabled");
 
-    Serial.print("26) Print states: ");
-    Serial.printf("%s\r\n", settings.enablePrintStates ? "Enabled" : "Disabled");
+    systemPrint("26) Print states: ");
+    systemPrintf("%s\r\n", settings.enablePrintStates ? "Enabled" : "Disabled");
 
-    Serial.print("27) Print duplicate states: ");
-    Serial.printf("%s\r\n", settings.enablePrintDuplicateStates ? "Enabled" : "Disabled");
+    systemPrint("27) Print duplicate states: ");
+    systemPrintf("%s\r\n", settings.enablePrintDuplicateStates ? "Enabled" : "Disabled");
 
-    Serial.print("28) RTCM message checking: ");
-    Serial.printf("%s\r\n", settings.enableRtcmMessageChecking ? "Enabled" : "Disabled");
+    systemPrint("28) RTCM message checking: ");
+    systemPrintf("%s\r\n", settings.enableRtcmMessageChecking ? "Enabled" : "Disabled");
 
-    Serial.print("29) Run Logging Test: ");
-    Serial.printf("%s\r\n", settings.runLogTest ? "Enabled" : "Disabled");
+    systemPrint("29) Run Logging Test: ");
+    systemPrintf("%s\r\n", settings.runLogTest ? "Enabled" : "Disabled");
 
-    Serial.println("30) Run Bluetooth Test");
+    systemPrintln("30) Run Bluetooth Test");
 
-    Serial.print("31) Print TCP status: ");
-    Serial.printf("%s\r\n", settings.enablePrintTcpStatus ? "Enabled" : "Disabled");
+    systemPrint("31) Print TCP status: ");
+    systemPrintf("%s\r\n", settings.enablePrintTcpStatus ? "Enabled" : "Disabled");
 
-    Serial.print("32) ESP-Now Broadcast Override: ");
-    Serial.printf("%s\r\n", settings.espnowBroadcast ? "Enabled" : "Disabled");
+    systemPrint("32) ESP-Now Broadcast Override: ");
+    systemPrintf("%s\r\n", settings.espnowBroadcast ? "Enabled" : "Disabled");
 
-    Serial.print("33) Print buffer overruns: ");
-    Serial.printf("%s\r\n", settings.enablePrintBufferOverrun ? "Enabled" : "Disabled");
+    systemPrint("33) Print buffer overruns: ");
+    systemPrintf("%s\r\n", settings.enablePrintBufferOverrun ? "Enabled" : "Disabled");
 
-    Serial.print("34) Set UART Receive Buffer Size: ");
-    Serial.println(settings.uartReceiveBufferSize);
+    systemPrint("34) Set UART Receive Buffer Size: ");
+    systemPrintln(settings.uartReceiveBufferSize);
 
-    Serial.print("35) Set GNSS Handler Buffer Size: ");
-    Serial.println(settings.gnssHandlerBufferSize);
+    systemPrint("35) Set GNSS Handler Buffer Size: ");
+    systemPrintln(settings.gnssHandlerBufferSize);
 
-    Serial.print("36) Print SD and UART buffer sizes: ");
-    Serial.printf("%s\r\n", settings.enablePrintSDBuffers ? "Enabled" : "Disabled");
+    systemPrint("36) Print SD and UART buffer sizes: ");
+    systemPrintf("%s\r\n", settings.enablePrintSDBuffers ? "Enabled" : "Disabled");
 
-    Serial.println("t) Enter Test Screen");
+    systemPrintln("t) Enter Test Screen");
 
-    Serial.println("e) Erase LittleFS");
+    systemPrintln("e) Erase LittleFS");
 
-    Serial.println("r) Force system reset");
+    systemPrintln("r) Force system reset");
 
-    Serial.println("x) Exit");
+    systemPrintln("x) Exit");
 
     byte incoming = getCharacterNumber();
 
@@ -551,36 +551,36 @@ void menuDebug()
     }
     else if (incoming == 4)
     {
-      Serial.print("Enter SPI frequency in MHz (1 to 16): ");
+      systemPrint("Enter SPI frequency in MHz (1 to 16): ");
       int freq = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((freq != INPUT_RESPONSE_GETNUMBER_EXIT) && (freq != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (freq < 1 || freq > 16) //Arbitrary 16MHz limit
-          Serial.println("Error: SPI frequency out of range");
+          systemPrintln("Error: SPI frequency out of range");
         else
           settings.spiFrequency = freq; //Recorded to NVM and file at main menu exit
       }
     }
     else if (incoming == 5)
     {
-      Serial.print("Enter SPP RX Queue Size in Bytes (32 to 16384): ");
+      systemPrint("Enter SPP RX Queue Size in Bytes (32 to 16384): ");
       int queSize = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((queSize != INPUT_RESPONSE_GETNUMBER_EXIT) && (queSize != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (queSize < 32 || queSize > 16384) //Arbitrary 16k limit
-          Serial.println("Error: Queue size out of range");
+          systemPrintln("Error: Queue size out of range");
         else
           settings.sppRxQueueSize = queSize; //Recorded to NVM and file at main menu exit
       }
     }
     else if (incoming == 6)
     {
-      Serial.print("Enter SPP TX Queue Size in Bytes (32 to 16384): ");
+      systemPrint("Enter SPP TX Queue Size in Bytes (32 to 16384): ");
       int queSize = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((queSize != INPUT_RESPONSE_GETNUMBER_EXIT) && (queSize != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (queSize < 32 || queSize > 16384) //Arbitrary 16k limit
-          Serial.println("Error: Queue size out of range");
+          systemPrintln("Error: Queue size out of range");
         else
           settings.sppTxQueueSize = queSize; //Recorded to NVM and file at main menu exit
       }
@@ -596,12 +596,12 @@ void menuDebug()
     }
     else if (incoming == 9)
     {
-      Serial.print("Enter GNSS Serial Timeout in milliseconds (0 to 1000): ");
+      systemPrint("Enter GNSS Serial Timeout in milliseconds (0 to 1000): ");
       int serialTimeoutGNSS = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((serialTimeoutGNSS != INPUT_RESPONSE_GETNUMBER_EXIT) && (serialTimeoutGNSS != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (serialTimeoutGNSS < 0 || serialTimeoutGNSS > 1000) //Arbitrary 1s limit
-          Serial.println("Error: Timeout is out of range");
+          systemPrintln("Error: Timeout is out of range");
         else
           settings.serialTimeoutGNSS = serialTimeoutGNSS; //Recorded to NVM and file at main menu exit
       }
@@ -639,9 +639,9 @@ void menuDebug()
       bool response = setMessagesUSB();
 
       if (response == false)
-        Serial.println(F("Failed to enable USB messages"));
+        systemPrintln(F("Failed to enable USB messages"));
       else
-        Serial.println(F("USB messages successfully enabled"));
+        systemPrintln(F("USB messages successfully enabled"));
     }
     else if (incoming == 18)
     {
@@ -714,24 +714,24 @@ void menuDebug()
     }
     else if (incoming == 34)
     {
-      Serial.print("Enter UART Receive Buffer Size in Bytes (32 to 16384): ");
+      systemPrint("Enter UART Receive Buffer Size in Bytes (32 to 16384): ");
       int queSize = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((queSize != INPUT_RESPONSE_GETNUMBER_EXIT) && (queSize != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (queSize < 32 || queSize > 16384) //Arbitrary 16k limit
-          Serial.println("Error: Queue size out of range");
+          systemPrintln("Error: Queue size out of range");
         else
           settings.uartReceiveBufferSize = queSize; //Recorded to NVM and file at main menu exit
       }
     }
     else if (incoming == 35)
     {
-      Serial.print("Enter GNSS Handler Buffer Size in Bytes (32 to 16384): ");
+      systemPrint("Enter GNSS Handler Buffer Size in Bytes (32 to 16384): ");
       int queSize = getNumber(); //Returns EXIT, TIMEOUT, or long
       if ((queSize != INPUT_RESPONSE_GETNUMBER_EXIT) && (queSize != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
       {
         if (queSize < 32 || queSize > 16384) //Arbitrary 16k limit
-          Serial.println("Error: Queue size out of range");
+          systemPrintln("Error: Queue size out of range");
         else
           settings.gnssHandlerBufferSize = queSize; //Recorded to NVM and file at main menu exit
       }
@@ -742,7 +742,7 @@ void menuDebug()
     }
     else if (incoming == 'e')
     {
-      Serial.println("Erasing LittleFS and resetting");
+      systemPrintln("Erasing LittleFS and resetting");
       LittleFS.format();
       ESP.restart();
     }
@@ -775,21 +775,21 @@ void printCurrentConditions()
 {
   if (online.gnss == true)
   {
-    Serial.print("SIV: ");
-    Serial.print(numSV);
+    systemPrint("SIV: ");
+    systemPrint(numSV);
 
-    Serial.print(", HPA (m): ");
-    Serial.print(horizontalAccuracy, 3);
+    systemPrint(", HPA (m): ");
+    systemPrint(horizontalAccuracy, 3);
 
-    Serial.print(", Lat: ");
-    Serial.print(latitude, haeNumberOfDecimals);
-    Serial.print(", Lon: ");
-    Serial.print(longitude, haeNumberOfDecimals);
+    systemPrint(", Lat: ");
+    systemPrint(latitude, haeNumberOfDecimals);
+    systemPrint(", Lon: ");
+    systemPrint(longitude, haeNumberOfDecimals);
 
-    Serial.print(", Altitude (m): ");
-    Serial.print(altitude, 1);
+    systemPrint(", Altitude (m): ");
+    systemPrint(altitude, 1);
 
-    Serial.println();
+    systemPrintln();
   }
 }
 
@@ -810,12 +810,12 @@ void printCurrentConditionsNMEA()
 
     char nmeaMessage[100]; //Max NMEA sentence length is 82
     createNMEASentence(CUSTOM_NMEA_TYPE_STATUS, nmeaMessage, systemStatus); //textID, buffer, text
-    Serial.println(nmeaMessage);
+    systemPrintln(nmeaMessage);
   }
   else
   {
     char nmeaMessage[100]; //Max NMEA sentence length is 82
     createNMEASentence(CUSTOM_NMEA_TYPE_STATUS, nmeaMessage, (char *)"OFFLINE"); //textID, buffer, text
-    Serial.println(nmeaMessage);
+    systemPrintln(nmeaMessage);
   }
 }

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -253,6 +253,13 @@ typedef enum
   INPUT_RESPONSE_VALID = 1,
 } InputResponse;
 
+typedef enum
+{
+  PRINT_ENDPOINT_SERIAL = 0,
+  PRINT_ENDPOINT_BLUETOOTH,
+  PRINT_ENDPOINT_ALL,
+} PrintEndpoint;
+PrintEndpoint printEndpoint = PRINT_ENDPOINT_SERIAL; //Controls where the configuration menu gets piped to
 
 typedef enum
 {


### PR DESCRIPTION
This PR changes all system prints to be directed at the local Serial.print, or Bluetooth.print, or both. This allows a user to use a Bluetooth serial app to control and configure the RTK device, without the need for the WiFi config page. 

To enter the 'Bluetooth Echo' mode:
* Open a bluetooth serial app such as [Serial Bluetooth Terminal for Android](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal&hl=en_US&gl=US&pli=1)
* Connect to the RTK Device
* Send the string +++

To exit the 'Bluetooth Echo' mode:
* Select 'b' from the configuration menu