### PR TITLE
WiFi network consolidation

### DIFF
--- a/Firmware/RTK_Surveyor/AP-Config/index.html
+++ b/Firmware/RTK_Surveyor/AP-Config/index.html
@@ -107,6 +107,7 @@
 
         <hr class="mt-0">
         <div style="margin-top:20px;">
+
             <!-- --------- Profile Config --------- -->
             <div class="d-grid gap-2">
                 <button class="btn btn-primary toggle-btn" id="profileConfig" type="button" data-toggle="collapse"
@@ -1552,6 +1553,141 @@
                 </div>
             </div>
 
+            <!-- --------- WiFi Config --------- -->
+            <div class="d-grid gap-2">
+                <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
+                    data-target="#collapseWiFiConfig" aria-expanded="false" aria-controls="collapseWiFiConfig">
+                    WiFi Configuration <i id="wifiCaret" class="caret-icon bi icon-caret-down"></i>
+                </button>
+            </div>
+            <div class="collapse" id="collapseWiFiConfig">
+                <div class="card card-body">
+
+                    <div class="form-group mt-2">
+                        Networks:
+                        <span class="tt" data-bs-placement="right"
+                            title="Enter credentials for up to 4 WiFi networks. All networks will be tried and the best network available will be used.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork0SSID" class="col-3 col-form-label">SSID 1:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork0SSID">
+                            <p id="wifiNetwork0SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork0Password" class="col-3 col-form-label">PW
+                            1:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork0Password">
+                            <p id="wifiNetwork0PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork1SSID" class="col-3 col-form-label">SSID 2:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork1SSID">
+                            <p id="wifiNetwork1SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork1Password" class="col-3 col-form-label">PW
+                            2:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork1Password">
+                            <p id="wifiNetwork1PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork2SSID" class="col-3 col-form-label">SSID 3:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork2SSID">
+                            <p id="wifiNetwork2SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork2Password" class="col-3 col-form-label">PW
+                            3:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork2Password">
+                            <p id="wifiNetwork2PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork3SSID" class="col-3 col-form-label">SSID 4:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork3SSID">
+                            <p id="wifiNetwork3SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork3Password" class="col-3 col-form-label">PW
+                            4:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork3Password">
+                            <p id="wifiNetwork3PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-check mt-3">
+                        <label class="form-check-label" for="enableTcpClient">TCP Client</label>
+                        <input class="form-check-input" type="checkbox" value="" id="enableTcpClient"
+                            onClick="tcpBoxes()">
+                        <span class="tt" data-bs-placement="right"
+                            title="If enabled, device will connect to WiFi and push NMEA over the given TCP port.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                    <div class="form-check mt-3">
+                        <label class="form-check-label" for="enableTcpServer">TCP Server</label>
+                        <input class="form-check-input" type="checkbox" value="" id="enableTcpServer"
+                            onClick="tcpBoxes()">
+                        <span class="tt" data-bs-placement="right"
+                            title="If enabled, device will allow inbound TCP connections and push NMEA when a client is connected.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                    <div id="tcpSettingsConfig">
+                        <div class="form-group row">
+                            <label for="wifiTcpPort" class="box-margin20 col-sm-3 col-4 col-form-label">Port:
+                                <span class="tt" data-bs-placement="right" title="TCP port to use. Default: 2947">
+                                    <span class="icon-info-circle text-primary ms-2"></span>
+                                </span>
+                            </label>
+                            <div class="col-sm-8 col-7">
+                                <input type="text" class="form-control" id="wifiTcpPort">
+                                <p id="wifiTcpPortError" class="inlineError"></p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="wifiConfigTypeDropdown" class="mt-3">
+                        <label for="wifiConfigType">Configure Mode: </label>
+                        <select name="wifiConfigType" id="wifiConfigOverAP" class="form-dropdown">
+                            <option value="1">AP</option>
+                            <option value="0">WiFi</option>
+                        </select>
+                        <span class="tt" data-bs-placement="right"
+                            title="In AP mode, the device will broadcast as an access point called RTK-Config. In WiFi mode, the device will connect to local WiFi and be configurable on the displayed IP address.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                </div>
+            </div>
+
             <!-- --------- Radio Config --------- -->
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
@@ -1741,9 +1877,9 @@
                         </span>
 
                         <div class="form-check">
-                            Free: <p id="sdFreeSpaceMB" style="display:inline;">0</p>MB
+                            Free: <p id="sdFreeSpace" style="display:inline;">0 MB</p>
                             <br>
-                            Used: <p id="sdUsedSpaceMB" style="display:inline;">0</p>MB
+                            Used: <p id="sdUsedSpace" style="display:inline;">0 MB</p>
                         </div>
                     </div>
                     <div class="col-sm-7 col-6 mt-2">
@@ -1778,7 +1914,7 @@
 
             <!-- --------- File Manager --------- -->
             <div class="d-grid gap-2">
-                <button onclick="getFileList()"" id="fileManager" class="btn btn-primary mt-3 toggle-btn" type="button"
+                <button onclick="getFileList()" id="fileManager" class="btn btn-primary mt-3 toggle-btn" type="button"
                     data-toggle="collapse" data-target="#collapseFileManager" aria-expanded="false"
                     aria-controls="collapseFileManager">
                     File Manager <i id="fileManagerCaret" class="caret-icon bi icon-caret-down"></i>

--- a/Firmware/RTK_Surveyor/AP-Config/src/main.js
+++ b/Firmware/RTK_Surveyor/AP-Config/src/main.js
@@ -1,12 +1,20 @@
-//var gateway = 'ws://192.168.0.140/ws'; //WiFi mode
-var gateway = 'ws://192.168.4.1/ws'; //AP mode
-var websocket = new WebSocket(gateway);
+var gateway = `ws://${window.location.hostname}/ws`;
+var websocket;
 var resetTimeout = 0;
 var saveTimeout = 0;
 
-websocket.onmessage = function (msg) {
-    parseIncoming(msg.data);
-};
+window.addEventListener('load', onLoad);
+
+function onLoad(event) {
+    initWebSocket();
+}
+
+function initWebSocket() {
+    websocket = new WebSocket(gateway);
+    websocket.onmessage = function (msg) {
+        parseIncoming(msg.data);
+    };
+}
 
 function ge(e) {
     return document.getElementById(e);
@@ -227,6 +235,7 @@ function parseIncoming(msg) {
     ge("radioType").dispatchEvent(new CustomEvent('change'));
     updateECEFList();
     updateGeodeticList();
+    tcpBoxes();
 }
 
 function hide(id) {
@@ -491,7 +500,7 @@ function validateFields() {
         }
     }
 
-    //L-Band Config
+    //PointPerfect Config
     if (platformPrefix == "Facet L-Band") {
         if (ge("enablePointPerfectCorrections").checked == true) {
             checkElementString("home_wifiSSID", 1, 30, "Must be 1 to 30 characters", "collapsePPConfig");
@@ -509,6 +518,20 @@ function validateFields() {
             ge("autoKeyRenewal").checked = true;
         }
     }
+
+    //WiFi Config
+    checkElementString("wifiNetwork0SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork0Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork1SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork1Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork2SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork2Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork3SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork3Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    if (ge("enableTcpClient").checked || ge("enableTcpServer").checked) {
+        checkElementString("wifiTcpPort", 1, 65535, "Must be 1 to 65535", "collapseWiFiConfig");
+    }
+
 
     //System Config
     if (ge("enableLogging").checked) {
@@ -1244,4 +1267,14 @@ function errorHandler(event) {
 }
 function abortHandler(event) {
     ge("uploadStatus").innerHTML = "Upload Aborted";
+}
+
+function tcpBoxes() {
+    if (ge("enableTcpClient").checked || ge("enableTcpServer").checked) {
+        show("tcpSettingsConfig");
+    }
+    else {
+        hide("tcpSettingsConfig");
+        ge("wifiTcpPort").value = 2947;
+    }
 }

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -482,8 +482,11 @@ void createSettingsString(char* settingsCSV)
   stringRecord(settingsCSV, "maxLogTime_minutes", settings.maxLogTime_minutes);
   stringRecord(settingsCSV, "maxLogLength_minutes", settings.maxLogLength_minutes);
 
-  stringRecord(settingsCSV, "sdFreeSpace", stringHumanReadableSize(sdFreeSpace));
-  stringRecord(settingsCSV, "sdUsedSpace", stringHumanReadableSize(sdCardSize - sdFreeSpace));
+  char sdSpace[30];
+  sprintf(sdSpace, "%s", stringHumanReadableSize(sdFreeSpace));
+  stringRecord(settingsCSV, "sdFreeSpace", sdSpace);
+  sprintf(sdSpace, "%s", stringHumanReadableSize(sdCardSize - sdFreeSpace));
+  stringRecord(settingsCSV, "sdUsedSpace", sdSpace);
 
   stringRecord(settingsCSV, "enableResetDisplay", settings.enableResetDisplay);
 
@@ -935,20 +938,18 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
       {
         char tempString[100]; //wifiNetwork0Password=parachutes
         sprintf(tempString, "wifiNetwork%dSSID", x);
-        settingsFile->println(tempString);
         if (strcmp(settingName, tempString) == 0)
         {
-          settings.wifiNetworks[x].ssid = settingValueStr;
+          strcpy(settings.wifiNetworks[x].ssid, settingValueStr);
           knownSetting = true;
           break;
         }
         else
         {
           sprintf(tempString, "wifiNetwork%dPassword", x);
-          settingsFile->println(tempString);
           if (strcmp(settingName, tempString) == 0)
           {
-            settings.wifiNetworks[x].password = settingValueStr;
+            strcpy(settings.wifiNetworks[x].password, settingValueStr);
             knownSetting = true;
             break;
           }

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -659,6 +659,7 @@ void createSettingsString(char* settingsCSV)
     stringRecord(settingsCSV, tagText, settings.wifiNetworks[x].password);
   }
   stringRecord(settingsCSV, "wifiConfigOverAP", settings.wifiConfigOverAP);
+  stringRecord(settingsCSV, "wifiTcpPort", settings.wifiTcpPort);
 
   //New settings not yet integrated
   //...
@@ -837,6 +838,8 @@ void updateSettingWithValue(const char *settingName, const char* settingValueStr
     recordLineToLFS(stationCoordinateGeodeticFileName, settingValueStr);
     log_d("%s recorded", settingValueStr);
   }
+  else if (strcmp(settingName, "wifiTcpPort") == 0)
+    settings.wifiTcpPort = settingValue;
 
   //Unused variables - read to avoid errors
   else if (strcmp(settingName, "measurementRateSec") == 0) {}

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -300,6 +300,7 @@ void recordSystemSettingsToFile(File * settingsFile)
   }
 
   settingsFile->printf("%s=%d\r\n", "wifiConfigOverAP", settings.wifiConfigOverAP);
+  settingsFile->printf("%s=%d\r\n", "wifiTcpPort", settings.wifiTcpPort);
 
   //Record constellation settings
   for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
@@ -923,6 +924,8 @@ bool parseLine(char* str, Settings *settings)
     settings->forceResetOnSDFail = d;
   else if (strcmp(settingName, "wifiConfigOverAP") == 0)
     settings->wifiConfigOverAP = d;
+  else if (strcmp(settingName, "wifiTcpPort") == 0)
+    settings->wifiTcpPort = d;
 
   //Check for bulk settings (WiFi credentials, constellations, message rates, ESPNOW Peers)
   //Must be last on else list

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -214,8 +214,6 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%s\r\n", "ntripServer_CasterUserPW", settings.ntripServer_CasterUserPW);
   settingsFile->printf("%s=%s\r\n", "ntripServer_MountPoint", settings.ntripServer_MountPoint);
   settingsFile->printf("%s=%s\r\n", "ntripServer_MountPointPW", settings.ntripServer_MountPointPW);
-  settingsFile->printf("%s=%s\r\n", "ntripServer_wifiSSID", settings.ntripServer_wifiSSID);
-  settingsFile->printf("%s=%s\r\n", "ntripServer_wifiPW", settings.ntripServer_wifiPW);
   settingsFile->printf("%s=%d\r\n", "enableNtripClient", settings.enableNtripClient);
   settingsFile->printf("%s=%s\r\n", "ntripClient_CasterHost", settings.ntripClient_CasterHost);
   settingsFile->printf("%s=%d\r\n", "ntripClient_CasterPort", settings.ntripClient_CasterPort);
@@ -223,14 +221,10 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%s\r\n", "ntripClient_CasterUserPW", settings.ntripClient_CasterUserPW);
   settingsFile->printf("%s=%s\r\n", "ntripClient_MountPoint", settings.ntripClient_MountPoint);
   settingsFile->printf("%s=%s\r\n", "ntripClient_MountPointPW", settings.ntripClient_MountPointPW);
-  settingsFile->printf("%s=%s\r\n", "ntripClient_wifiSSID", settings.ntripClient_wifiSSID);
-  settingsFile->printf("%s=%s\r\n", "ntripClient_wifiPW", settings.ntripClient_wifiPW);
   settingsFile->printf("%s=%d\r\n", "ntripClient_TransmitGGA", settings.ntripClient_TransmitGGA);
   settingsFile->printf("%s=%d\r\n", "serialTimeoutGNSS", settings.serialTimeoutGNSS);
   settingsFile->printf("%s=%s\r\n", "pointPerfectDeviceProfileToken", settings.pointPerfectDeviceProfileToken);
   settingsFile->printf("%s=%d\r\n", "enablePointPerfectCorrections", settings.enablePointPerfectCorrections);
-  settingsFile->printf("%s=%s\r\n", "home_wifiSSID", settings.home_wifiSSID);
-  settingsFile->printf("%s=%s\r\n", "home_wifiPW", settings.home_wifiPW);
   settingsFile->printf("%s=%d\r\n", "autoKeyRenewal", settings.autoKeyRenewal);
   settingsFile->printf("%s=%s\r\n", "pointPerfectClientID", settings.pointPerfectClientID);
   settingsFile->printf("%s=%s\r\n", "pointPerfectBrokerHost", settings.pointPerfectBrokerHost);
@@ -294,6 +288,18 @@ void recordSystemSettingsToFile(File * settingsFile)
   settingsFile->printf("%s=%d\r\n", "gnssHandlerBufferSize", settings.gnssHandlerBufferSize);
   settingsFile->printf("%s=%d\r\n", "enablePrintBufferOverrun", settings.enablePrintBufferOverrun);
   settingsFile->printf("%s=%d\r\n", "forceResetOnSDFail", settings.forceResetOnSDFail);
+
+  //Record WiFi credential table
+  for (int x = 0 ; x < MAX_WIFI_NETWORKS ; x++)
+  {
+    char tempString[100]; //wifiNetwork0Password=parachutes
+    sprintf(tempString, "wifiNetwork%dSSID=%s", x, settings.wifiNetworks[x].ssid);
+    settingsFile->println(tempString);
+    sprintf(tempString, "wifiNetwork%dPassword=%s", x, settings.wifiNetworks[x].password);
+    settingsFile->println(tempString);
+  }
+
+  settingsFile->printf("%s=%d\r\n", "wifiConfigOverAP", settings.wifiConfigOverAP);
 
   //Record constellation settings
   for (int x = 0 ; x < MAX_CONSTELLATIONS ; x++)
@@ -793,10 +799,6 @@ bool parseLine(char* str, Settings *settings)
     strcpy(settings->ntripServer_MountPoint, settingValue);
   else if (strcmp(settingName, "ntripServer_MountPointPW") == 0)
     strcpy(settings->ntripServer_MountPointPW, settingValue);
-  else if (strcmp(settingName, "ntripServer_wifiSSID") == 0)
-    strcpy(settings->ntripServer_wifiSSID, settingValue);
-  else if (strcmp(settingName, "ntripServer_wifiPW") == 0)
-    strcpy(settings->ntripServer_wifiPW, settingValue);
   else if (strcmp(settingName, "enableNtripClient") == 0)
     settings->enableNtripClient = d;
   else if (strcmp(settingName, "ntripClient_CasterHost") == 0)
@@ -811,10 +813,6 @@ bool parseLine(char* str, Settings *settings)
     strcpy(settings->ntripClient_MountPoint, settingValue);
   else if (strcmp(settingName, "ntripClient_MountPointPW") == 0)
     strcpy(settings->ntripClient_MountPointPW, settingValue);
-  else if (strcmp(settingName, "ntripClient_wifiSSID") == 0)
-    strcpy(settings->ntripClient_wifiSSID, settingValue);
-  else if (strcmp(settingName, "ntripClient_wifiPW") == 0)
-    strcpy(settings->ntripClient_wifiPW, settingValue);
   else if (strcmp(settingName, "ntripClient_TransmitGGA") == 0)
     settings->ntripClient_TransmitGGA = d;
   else if (strcmp(settingName, "serialTimeoutGNSS") == 0)
@@ -823,10 +821,6 @@ bool parseLine(char* str, Settings *settings)
     strcpy(settings->pointPerfectDeviceProfileToken, settingValue);
   else if (strcmp(settingName, "enablePointPerfectCorrections") == 0)
     settings->enablePointPerfectCorrections = d;
-  else if (strcmp(settingName, "home_wifiSSID") == 0)
-    strcpy(settings->home_wifiSSID, settingValue);
-  else if (strcmp(settingName, "home_wifiPW") == 0)
-    strcpy(settings->home_wifiPW, settingValue);
   else if (strcmp(settingName, "autoKeyRenewal") == 0)
     settings->autoKeyRenewal = d;
   else if (strcmp(settingName, "pointPerfectClientID") == 0)
@@ -927,12 +921,40 @@ bool parseLine(char* str, Settings *settings)
     settings->enablePrintBufferOverrun = d;
   else if (strcmp(settingName, "forceResetOnSDFail") == 0)
     settings->forceResetOnSDFail = d;
+  else if (strcmp(settingName, "wifiConfigOverAP") == 0)
+    settings->wifiConfigOverAP = d;
 
-  //Check for bulk settings (constellations, message rates, ESPNOW Peers)
+  //Check for bulk settings (WiFi credentials, constellations, message rates, ESPNOW Peers)
   //Must be last on else list
   else
   {
     bool knownSetting = false;
+
+    //Scan for WiFi settings
+    if (knownSetting == false)
+    {
+      for (int x = 0 ; x < MAX_WIFI_NETWORKS ; x++)
+      {
+        char tempString[100]; //wifiNetwork0Password=parachutes
+        sprintf(tempString, "wifiNetwork%dSSID", x);
+        if (strcmp(settingName, tempString) == 0)
+        {
+          strcpy(settings->wifiNetworks[x].ssid, settingValue);
+          knownSetting = true;
+          break;
+        }
+        else
+        {
+          sprintf(tempString, "wifiNetwork%dPassword", x);
+          if (strcmp(settingName, tempString) == 0)
+          {
+            strcpy(settings->wifiNetworks[x].password, settingValue);
+            knownSetting = true;
+            break;
+          }
+        }
+      }
+    }
 
     //Scan for constellation settings
     if (knownSetting == false)

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -330,7 +330,7 @@ void ntripClientUpdate()
 
     //Start WiFi
     case NTRIP_CLIENT_ON:
-      if (strlen(settings.ntripClient_wifiSSID) == 0)
+      if (wifiNetworkCount() == 0)
       {
         systemPrintln("Error: Please enter SSID before starting NTRIP Client");
         ntripClientSetState(NTRIP_CLIENT_OFF);
@@ -341,7 +341,7 @@ void ntripClientUpdate()
         if (millis() - ntripClientLastConnectionAttempt > ntripClientConnectionAttemptTimeout)
         {
           ntripClientLastConnectionAttempt = millis();
-          wifiStart(settings.ntripClient_wifiSSID, settings.ntripClient_wifiPW);
+          wifiStart();
           ntripClientSetState(NTRIP_CLIENT_WIFI_CONNECTING);
         }
         else
@@ -363,10 +363,11 @@ void ntripClientUpdate()
       if (!wifiIsConnected())
       {
         //Throttle if SSID is not detected
-        if (wifiConnectionTimeout() || wifiGetStatus() == WL_NO_SSID_AVAIL)
+        if (wifiConnectionTimeout() || wifiGetStatus() == WL_DISCONNECTED)
         {
-          if (wifiGetStatus() == WL_NO_SSID_AVAIL)
-            systemPrintf("WiFi network '%s' not found\r\n", settings.ntripClient_wifiSSID);
+          //WL_NO_SSID_AVAIL was originally used but WiFiMulti puts radio into WL_DISCONNECTED state if no matching SSIDs are detected
+          if (wifiGetStatus() == WL_DISCONNECTED)
+            systemPrintln("No matching WiFi networks found");
 
           if (ntripClientConnectLimitReached()) //Stop WiFi, give up
             paintNtripWiFiFail(4000, true);

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -332,7 +332,7 @@ void ntripClientUpdate()
     case NTRIP_CLIENT_ON:
       if (wifiNetworkCount() == 0)
       {
-        systemPrintln("Error: Please enter SSID before starting NTRIP Client");
+        systemPrintln("Error: Please enter at least one SSID before starting NTRIP Client");
         ntripClientSetState(NTRIP_CLIENT_OFF);
       }
       else

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -351,7 +351,7 @@ void ntripServerUpdate()
 
     //Start WiFi
     case NTRIP_SERVER_ON:
-      if (strlen(settings.ntripServer_wifiSSID) == 0)
+      if (wifiNetworkCount() == 0)
       {
         systemPrintln("Error: Please enter SSID before starting NTRIP Server");
         ntripServerSetState(NTRIP_SERVER_OFF);
@@ -362,7 +362,7 @@ void ntripServerUpdate()
         if (millis() - ntripServerLastConnectionAttempt > ntripServerConnectionAttemptTimeout)
         {
           ntripServerLastConnectionAttempt = millis();
-          wifiStart(settings.ntripServer_wifiSSID, settings.ntripServer_wifiPW);
+          wifiStart();
           ntripServerSetState(NTRIP_SERVER_WIFI_CONNECTING);
         }
         else
@@ -384,10 +384,11 @@ void ntripServerUpdate()
       if (!wifiIsConnected())
       {
         //Throttle if SSID is not detected
-        if (wifiConnectionTimeout() || wifiGetStatus() == WL_NO_SSID_AVAIL)
+        if (wifiConnectionTimeout() || wifiGetStatus() == WL_DISCONNECTED)
         {
-          if (wifiGetStatus() == WL_NO_SSID_AVAIL)
-            systemPrintf("WiFi network '%s' not found\r\n", settings.ntripServer_wifiSSID);
+          //WL_NO_SSID_AVAIL was originally used but WiFiMulti puts radio into WL_DISCONNECTED state if no matching SSIDs are detected
+          if (wifiGetStatus() == WL_DISCONNECTED)
+            systemPrintln("No matching WiFi networks found");
 
           if (ntripServerConnectLimitReached())
           {

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -353,7 +353,7 @@ void ntripServerUpdate()
     case NTRIP_SERVER_ON:
       if (wifiNetworkCount() == 0)
       {
-        systemPrintln("Error: Please enter SSID before starting NTRIP Server");
+        systemPrintln("Error: Please enter at least one SSID before starting NTRIP Server");
         ntripServerSetState(NTRIP_SERVER_OFF);
       }
       else

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -165,6 +165,7 @@ bool sdSizeCheckTaskComplete = false;
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 #ifdef COMPILE_WIFI
 #include <WiFi.h> //Built-in.
+#include <WiFiMulti.h> //Built-in.
 #include <HTTPClient.h> //Built-in. Needed for ThingStream API for ZTP
 #include <ArduinoJson.h> //http://librarymanager/All#Arduino_JSON_messagepack v6.19.4
 #include <WiFiClientSecure.h> //Built-in.

--- a/Firmware/RTK_Surveyor/States.ino
+++ b/Firmware/RTK_Surveyor/States.ino
@@ -685,7 +685,7 @@ void updateSystemState()
           }
 
           //If there is no WiFi setup, and no keys, skip everything
-          else if (strlen(settings.home_wifiSSID) == 0 && strlen(settings.pointPerfectCurrentKey) == 0)
+          else if (wifiNetworkCount() == 0 && strlen(settings.pointPerfectCurrentKey) == 0)
           {
             changeState(settings.lastState); //Go to either rover or base
           }
@@ -693,7 +693,7 @@ void updateSystemState()
           //If we don't have keys, begin zero touch provisioning
           else if (strlen(settings.pointPerfectCurrentKey) == 0 || strlen(settings.pointPerfectNextKey) == 0)
           {
-            wifiStart(settings.home_wifiSSID, settings.home_wifiPW);
+            wifiStart();
             changeState(STATE_KEYS_PROVISION_WIFI_STARTED);
           }
 
@@ -727,7 +727,7 @@ void updateSystemState()
 
           if (online.rtc == false)
           {
-            wifiStart(settings.home_wifiSSID, settings.home_wifiPW);
+            wifiStart();
             changeState(STATE_KEYS_WIFI_STARTED); //If we can't check the RTC, continue
           }
 
@@ -737,7 +737,7 @@ void updateSystemState()
             settings.lastKeyAttempt = rtc.getEpoch(); //Mark it
             recordSystemSettings(); //Record these settings to unit
 
-            wifiStart(settings.home_wifiSSID, settings.home_wifiPW);
+            wifiStart();
             changeState(STATE_KEYS_WIFI_STARTED);
           }
           else

--- a/Firmware/RTK_Surveyor/form.h
+++ b/Firmware/RTK_Surveyor/form.h
@@ -21,15 +21,23 @@
 //Convert file to hex at http://tomeko.net/online_tools/file_to_hex.php?lang=en
 
 static const char *main_js = R"=====(
-//var gateway = 'ws://192.168.0.140/ws'; //WiFi mode
-var gateway = 'ws://192.168.4.1/ws'; //AP mode
-var websocket = new WebSocket(gateway);
+var gateway = `ws://${window.location.hostname}/ws`;
+var websocket;
 var resetTimeout = 0;
 var saveTimeout = 0;
 
-websocket.onmessage = function (msg) {
-    parseIncoming(msg.data);
-};
+window.addEventListener('load', onLoad);
+
+function onLoad(event) {
+    initWebSocket();
+}
+
+function initWebSocket() {
+    websocket = new WebSocket(gateway);
+    websocket.onmessage = function (msg) {
+        parseIncoming(msg.data);
+    };
+}
 
 function ge(e) {
     return document.getElementById(e);
@@ -250,6 +258,7 @@ function parseIncoming(msg) {
     ge("radioType").dispatchEvent(new CustomEvent('change'));
     updateECEFList();
     updateGeodeticList();
+    tcpBoxes();
 }
 
 function hide(id) {
@@ -514,7 +523,7 @@ function validateFields() {
         }
     }
 
-    //L-Band Config
+    //PointPerfect Config
     if (platformPrefix == "Facet L-Band") {
         if (ge("enablePointPerfectCorrections").checked == true) {
             checkElementString("home_wifiSSID", 1, 30, "Must be 1 to 30 characters", "collapsePPConfig");
@@ -532,6 +541,20 @@ function validateFields() {
             ge("autoKeyRenewal").checked = true;
         }
     }
+
+    //WiFi Config
+    checkElementString("wifiNetwork0SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork0Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork1SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork1Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork2SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork2Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork3SSID", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    checkElementString("wifiNetwork3Password", 0, 50, "Must be 0 to 50 characters", "collapseWiFiConfig");
+    if (ge("enableTcpClient").checked || ge("enableTcpServer").checked) {
+        checkElementString("wifiTcpPort", 1, 65535, "Must be 1 to 65535", "collapseWiFiConfig");
+    }
+
 
     //System Config
     if (ge("enableLogging").checked) {
@@ -1269,6 +1292,15 @@ function abortHandler(event) {
     ge("uploadStatus").innerHTML = "Upload Aborted";
 }
 
+function tcpBoxes() {
+    if (ge("enableTcpClient").checked || ge("enableTcpServer").checked) {
+        show("tcpSettingsConfig");
+    }
+    else {
+        hide("tcpSettingsConfig");
+        ge("wifiTcpPort").value = 2947;
+    }
+}
 
 )====="; //End main.js
 
@@ -1382,6 +1414,7 @@ static const char *index_html = R"=====(
 
         <hr class="mt-0">
         <div style="margin-top:20px;">
+
             <!-- --------- Profile Config --------- -->
             <div class="d-grid gap-2">
                 <button class="btn btn-primary toggle-btn" id="profileConfig" type="button" data-toggle="collapse"
@@ -2827,6 +2860,142 @@ static const char *index_html = R"=====(
                 </div>
             </div>
 
+            <!-- --------- WiFi Config --------- -->
+            <div class="d-grid gap-2">
+                <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
+                    data-target="#collapseWiFiConfig" aria-expanded="false" aria-controls="collapseWiFiConfig">
+                    WiFi Configuration <i id="wifiCaret" class="caret-icon bi icon-caret-down"></i>
+                </button>
+            </div>
+            <div class="collapse show" id="collapseWiFiConfig">
+                <div class="card card-body">
+
+                    <div class="form-group mt-2">
+                        Networks:
+                        <span class="tt" data-bs-placement="right"
+                            title="Enter credentials for up to 4 WiFi networks. All networks will be tried and the best network available will be used.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork0SSID" class="col-3 col-form-label">SSID 1:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork0SSID">
+                            <p id="wifiNetwork0SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork0Password" class="col-3 col-form-label">PW
+                            1:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork0Password">
+                            <p id="wifiNetwork0PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork1SSID" class="col-3 col-form-label">SSID 2:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork1SSID">
+                            <p id="wifiNetwork1SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork1Password" class="col-3 col-form-label">PW
+                            2:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork1Password">
+                            <p id="wifiNetwork1PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork2SSID" class="col-3 col-form-label">SSID 3:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork2SSID">
+                            <p id="wifiNetwork2SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork2Password" class="col-3 col-form-label">PW
+                            3:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork2Password">
+                            <p id="wifiNetwork2PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork3SSID" class="col-3 col-form-label">SSID 4:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork3SSID">
+                            <p id="wifiNetwork3SSIDError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="wifiNetwork3Password" class="col-3 col-form-label">PW
+                            4:</label>
+                        <div class="col-sm-8 col-7">
+                            <input type="text" class="form-control" id="wifiNetwork3Password">
+                            <p id="wifiNetwork3PasswordError" class="inlineError"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-check mt-3">
+                        <label class="form-check-label" for="enableTcpClient">TCP Client</label>
+                        <input class="form-check-input" type="checkbox" value="" id="enableTcpClient"
+                            onClick="tcpBoxes()">
+                        <span class="tt" data-bs-placement="right"
+                            title="If enabled, device will connect to WiFi and push NMEA over the given TCP port.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                    <div class="form-check mt-3">
+                        <label class="form-check-label" for="enableTcpServer">TCP Server</label>
+                        <input class="form-check-input" type="checkbox" value="" id="enableTcpServer"
+                            onClick="tcpBoxes()">
+                        <span class="tt" data-bs-placement="right"
+                            title="If enabled, device will allow inbound TCP connections and push NMEA when a client is connected.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                    <div id="tcpSettingsConfig">
+                        <div class="form-group row">
+                            <label for="wifiTcpPort" class="box-margin20 col-sm-3 col-4 col-form-label">Port:
+                                <span class="tt" data-bs-placement="right" title="TCP port to use. Default: 2947">
+                                    <span class="icon-info-circle text-primary ms-2"></span>
+                                </span>
+                            </label>
+                            <div class="col-sm-8 col-7">
+                                <input type="text" class="form-control" id="wifiTcpPort">
+                                <p id="wifiTcpPortError" class="inlineError"></p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="wifiConfigTypeDropdown" class="mt-3">
+                        <label for="wifiConfigType">Configure Mode: </label>
+                        <select name="wifiConfigType" id="wifiConfigOverAP" class="form-dropdown">
+                            <option value="1">AP</option>
+                            <option value="0">WiFi</option>
+                        </select>
+                        <span class="tt" data-bs-placement="right"
+                            title="In AP mode, the device will broadcast as an access point called RTK-Config. In WiFi mode, the device will connect to local WiFi and be configurable on the displayed IP address.">
+                            <span class="icon-info-circle text-primary ms-2"></span>
+                        </span>
+                    </div>
+
+                </div>
+            </div>
+
             <!-- --------- Radio Config --------- -->
             <div class="d-grid gap-2">
                 <button class="btn btn-primary mt-3 toggle-btn" type="button" data-toggle="collapse"
@@ -3016,9 +3185,9 @@ static const char *index_html = R"=====(
                         </span>
 
                         <div class="form-check">
-                            Free: <p id="sdFreeSpace" style="display:inline;">0 MB</p>
+                            Free: <p id="sdFreeSpaceMB" style="display:inline;">0</p>MB
                             <br>
-                            Used: <p id="sdUsedSpace" style="display:inline;">0 MB</p>
+                            Used: <p id="sdUsedSpaceMB" style="display:inline;">0</p>MB
                         </div>
                     </div>
                     <div class="col-sm-7 col-6 mt-2">

--- a/Firmware/RTK_Surveyor/menuBase.ino
+++ b/Firmware/RTK_Surveyor/menuBase.ino
@@ -65,27 +65,21 @@ void menuBase()
 
     if (settings.enableNtripServer == true)
     {
-      systemPrint("7) Set WiFi SSID: ");
-      systemPrintln(settings.ntripServer_wifiSSID);
-
-      systemPrint("8) Set WiFi PW: ");
-      systemPrintln(settings.ntripServer_wifiPW);
-
-      systemPrint("9) Set Caster Address: ");
+      systemPrint("7) Set Caster Address: ");
       systemPrintln(settings.ntripServer_CasterHost);
 
-      systemPrint("10) Set Caster Port: ");
+      systemPrint("8) Set Caster Port: ");
       systemPrintln(settings.ntripServer_CasterPort);
 
-      systemPrint("11) Set Mountpoint: ");
+      systemPrint("9) Set Mountpoint: ");
       systemPrintln(settings.ntripServer_MountPoint);
 
-      systemPrint("12) Set Mountpoint PW: ");
+      systemPrint("10) Set Mountpoint PW: ");
       systemPrintln(settings.ntripServer_MountPointPW);
     }
 
     if (!settings.fixedBase) {
-      systemPrint("13) Select survey-in radio: ");
+      systemPrint("11) Select survey-in radio: ");
       systemPrintf("%s\r\n", settings.ntripServer_StartAtSurveyIn ? "WiFi" : "Bluetooth");
     }
 
@@ -221,23 +215,11 @@ void menuBase()
     }
     else if (incoming == 7 && settings.enableNtripServer == true)
     {
-      systemPrint("Enter local WiFi SSID: ");
-      getString(settings.ntripServer_wifiSSID, sizeof(settings.ntripServer_wifiSSID));
-      restartBase = true;
-    }
-    else if (incoming == 8 && settings.enableNtripServer == true)
-    {
-      systemPrintf("Enter password for WiFi network %s: ", settings.ntripServer_wifiSSID);
-      getString(settings.ntripServer_wifiPW, sizeof(settings.ntripServer_wifiPW));
-      restartBase = true;
-    }
-    else if (incoming == 9 && settings.enableNtripServer == true)
-    {
       systemPrint("Enter new Caster Address: ");
       getString(settings.ntripServer_CasterHost, sizeof(settings.ntripServer_CasterHost));
       restartBase = true;
     }
-    else if (incoming == 10 && settings.enableNtripServer == true)
+    else if (incoming == 8 && settings.enableNtripServer == true)
     {
       systemPrint("Enter new Caster Port: ");
 
@@ -251,19 +233,19 @@ void menuBase()
         restartBase = true;
       }
     }
-    else if (incoming == 11 && settings.enableNtripServer == true)
+    else if (incoming == 9 && settings.enableNtripServer == true)
     {
       systemPrint("Enter new Mount Point: ");
       getString(settings.ntripServer_MountPoint, sizeof(settings.ntripServer_MountPoint));
       restartBase = true;
     }
-    else if (incoming == 12 && settings.enableNtripServer == true)
+    else if (incoming == 10 && settings.enableNtripServer == true)
     {
       systemPrintf("Enter password for Mount Point %s: ", settings.ntripServer_MountPoint);
       getString(settings.ntripServer_MountPointPW, sizeof(settings.ntripServer_MountPointPW));
       restartBase = true;
     }
-    else if ((!settings.fixedBase) && (incoming == 13))
+    else if ((!settings.fixedBase) && (incoming == 11))
     {
       settings.ntripServer_StartAtSurveyIn ^= 1;
       restartBase = true;

--- a/Firmware/RTK_Surveyor/menuGNSS.ino
+++ b/Firmware/RTK_Surveyor/menuGNSS.ino
@@ -65,31 +65,25 @@ void menuGNSS()
 
     if (settings.enableNtripClient == true)
     {
-      systemPrint("6) Set WiFi SSID: ");
-      systemPrintln(settings.ntripClient_wifiSSID);
-
-      systemPrint("7) Set WiFi PW: ");
-      systemPrintln(settings.ntripClient_wifiPW);
-
-      systemPrint("8) Set Caster Address: ");
+      systemPrint("6) Set Caster Address: ");
       systemPrintln(settings.ntripClient_CasterHost);
 
-      systemPrint("9) Set Caster Port: ");
+      systemPrint("7) Set Caster Port: ");
       systemPrintln(settings.ntripClient_CasterPort);
 
-      systemPrint("10) Set Caster User Name: ");
+      systemPrint("8) Set Caster User Name: ");
       systemPrintln(settings.ntripClient_CasterUser);
 
-      systemPrint("11) Set Caster User Password: ");
+      systemPrint("9) Set Caster User Password: ");
       systemPrintln(settings.ntripClient_CasterUserPW);
 
-      systemPrint("12) Set Mountpoint: ");
+      systemPrint("10) Set Mountpoint: ");
       systemPrintln(settings.ntripClient_MountPoint);
 
-      systemPrint("13) Set Mountpoint PW: ");
+      systemPrint("11) Set Mountpoint PW: ");
       systemPrintln(settings.ntripClient_MountPointPW);
 
-      systemPrint("14) Toggle sending GGA Location to Caster: ");
+      systemPrint("12) Toggle sending GGA Location to Caster: ");
       if (settings.ntripClient_TransmitGGA == true) systemPrintln("Enabled");
       else systemPrintln("Disabled");
     }
@@ -165,23 +159,11 @@ void menuGNSS()
     }
     else if (incoming == 6 && settings.enableNtripClient == true)
     {
-      systemPrint("Enter local WiFi SSID: ");
-      getString(settings.ntripClient_wifiSSID, sizeof(settings.ntripClient_wifiSSID));
-      restartRover = true;
-    }
-    else if (incoming == 7 && settings.enableNtripClient == true)
-    {
-      systemPrintf("Enter password for WiFi network %s: ", settings.ntripClient_wifiSSID);
-      getString(settings.ntripClient_wifiPW, sizeof(settings.ntripClient_wifiPW));
-      restartRover = true;
-    }
-    else if (incoming == 8 && settings.enableNtripClient == true)
-    {
       systemPrint("Enter new Caster Address: ");
       getString(settings.ntripClient_CasterHost, sizeof(settings.ntripClient_CasterHost));
       restartRover = true;
     }
-    else if (incoming == 9 && settings.enableNtripClient == true)
+    else if (incoming == 7 && settings.enableNtripClient == true)
     {
       systemPrint("Enter new Caster Port: ");
 
@@ -195,31 +177,31 @@ void menuGNSS()
         restartRover = true;
       }
     }
-    else if (incoming == 10 && settings.enableNtripClient == true)
+    else if (incoming == 8 && settings.enableNtripClient == true)
     {
       systemPrintf("Enter user name for %s: ", settings.ntripClient_CasterHost);
       getString(settings.ntripClient_CasterUser, sizeof(settings.ntripClient_CasterUser));
       restartRover = true;
     }
-    else if (incoming == 11 && settings.enableNtripClient == true)
+    else if (incoming == 9 && settings.enableNtripClient == true)
     {
       systemPrintf("Enter user password for %s: ", settings.ntripClient_CasterHost);
       getString(settings.ntripClient_CasterUserPW, sizeof(settings.ntripClient_CasterUserPW));
       restartRover = true;
     }
-    else if (incoming == 12 && settings.enableNtripClient == true)
+    else if (incoming == 10 && settings.enableNtripClient == true)
     {
       systemPrint("Enter new Mount Point: ");
       getString(settings.ntripClient_MountPoint, sizeof(settings.ntripClient_MountPoint));
       restartRover = true;
     }
-    else if (incoming == 13 && settings.enableNtripClient == true)
+    else if (incoming == 11 && settings.enableNtripClient == true)
     {
       systemPrintf("Enter password for Mount Point %s: ", settings.ntripClient_MountPoint);
       getString(settings.ntripClient_MountPointPW, sizeof(settings.ntripClient_MountPointPW));
       restartRover = true;
     }
-    else if (incoming == 14 && settings.enableNtripClient == true)
+    else if (incoming == 12 && settings.enableNtripClient == true)
     {
       settings.ntripClient_TransmitGGA ^= 1;
       restartRover = true;

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -55,6 +55,8 @@ void menuMain()
 
     systemPrintln("5) Configure Logging");
 
+    systemPrintln("6) Configure WiFi");
+
     systemPrintln("p) Configure User Profiles");
 
 #ifdef COMPILE_ESPNOW
@@ -88,6 +90,8 @@ void menuMain()
       menuPorts();
     else if (incoming == 5)
       menuLog();
+    else if (incoming == 6)
+      menuWiFi();
     else if (incoming == 's')
       menuSystem();
     else if (incoming == 'p')

--- a/Firmware/RTK_Surveyor/menuPP.ino
+++ b/Firmware/RTK_Surveyor/menuPP.ino
@@ -948,20 +948,14 @@ void menuPointPerfect()
     if (settings.enablePointPerfectCorrections == true) systemPrintln("Enabled");
     else systemPrintln("Disabled");
 
-    systemPrint("2) Set Home WiFi SSID: ");
-    systemPrintln(settings.home_wifiSSID);
-
-    systemPrint("3) Set Home WiFi PW: ");
-    systemPrintln(settings.home_wifiPW);
-
-    systemPrint("4) Toggle Auto Key Renewal: ");
+    systemPrint("2) Toggle Auto Key Renewal: ");
     if (settings.autoKeyRenewal == true) systemPrintln("Enabled");
     else systemPrintln("Disabled");
 
     if (strlen(settings.pointPerfectCurrentKey) == 0 || strlen(settings.pointPerfectLBandTopic) == 0)
-      systemPrintln("5) Provision Device");
+      systemPrintln("3) Provision Device");
     else
-      systemPrintln("5) Update Keys");
+      systemPrintln("3) Update Keys");
 
     systemPrintln("k) Manual Key Entry");
 
@@ -975,28 +969,18 @@ void menuPointPerfect()
     }
     else if (incoming == 2)
     {
-      systemPrint("Enter Home WiFi SSID: ");
-      getString(settings.home_wifiSSID, sizeof(settings.home_wifiSSID));
+      settings.autoKeyRenewal ^= 1;
     }
     else if (incoming == 3)
     {
-      systemPrintf("Enter password for Home WiFi network %s: ", settings.home_wifiSSID);
-      getString(settings.home_wifiPW, sizeof(settings.home_wifiPW));
-    }
-    else if (incoming == 4)
-    {
-      settings.autoKeyRenewal ^= 1;
-    }
-    else if (incoming == 5)
-    {
 #ifdef COMPILE_WIFI
-      if (strlen(settings.home_wifiSSID) == 0)
+      if (wifiNetworkCount() == 0)
       {
-        systemPrintln("Error: Please enter SSID before getting keys");
+        systemPrintln("Error: Please enter at least one SSID before getting keys");
       }
       else
       {
-        wifiStart(settings.home_wifiSSID, settings.home_wifiPW);
+        wifiStart();
 
         unsigned long startTime = millis();
         while (wifiGetStatus() != WL_CONNECTED)
@@ -1012,7 +996,6 @@ void menuPointPerfect()
 
         if (wifiGetStatus() == WL_CONNECTED)
         {
-
           systemPrintln();
           systemPrint("WiFi connected: ");
           systemPrintln(wifiGetIpAddress());

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -72,8 +72,8 @@ void menuSystem()
 #ifdef COMPILE_WIFI
     systemPrint("WiFi MAC Address: ");
     systemPrintf("%02X:%02X:%02X:%02X:%02X:%02X\r\n", wifiMACAddress[0],
-                  wifiMACAddress[1], wifiMACAddress[2], wifiMACAddress[3],
-                  wifiMACAddress[4], wifiMACAddress[5]);
+                 wifiMACAddress[1], wifiMACAddress[2], wifiMACAddress[3],
+                 wifiMACAddress[4], wifiMACAddress[5]);
     if (wifiState == WIFI_CONNECTED)
       wifiDisplayIpAddress();
 #endif
@@ -99,12 +99,12 @@ void menuSystem()
 
     systemPrint("System Uptime: ");
     systemPrintf("%d %02d:%02d:%02d.%03lld (Resets: %d)\r\n",
-                  uptimeDays,
-                  uptimeHours,
-                  uptimeMinutes,
-                  uptimeSeconds,
-                  uptimeMilliseconds,
-                  settings.resetCount);
+                 uptimeDays,
+                 uptimeHours,
+                 uptimeMinutes,
+                 uptimeSeconds,
+                 uptimeMilliseconds,
+                 settings.resetCount);
 
     //Display NTRIP Client status and uptime
     if (settings.enableNtripClient == true && (systemState >= STATE_ROVER_NOT_STARTED && systemState <= STATE_ROVER_RTK_FIX))
@@ -146,12 +146,12 @@ void menuSystem()
 
       systemPrint(" Uptime: ");
       systemPrintf("%d %02d:%02d:%02d.%03lld (Reconnects: %d)\r\n",
-                    uptimeDays,
-                    uptimeHours,
-                    uptimeMinutes,
-                    uptimeSeconds,
-                    uptimeMilliseconds,
-                    ntripClientConnectionAttemptsTotal);
+                   uptimeDays,
+                   uptimeHours,
+                   uptimeMinutes,
+                   uptimeSeconds,
+                   uptimeMilliseconds,
+                   ntripClientConnectionAttemptsTotal);
     }
 
     //Display NTRIP Server status and uptime
@@ -196,12 +196,12 @@ void menuSystem()
 
       systemPrint(" Uptime: ");
       systemPrintf("%d %02d:%02d:%02d.%03lld (Reconnects: %d)\r\n",
-                    uptimeDays,
-                    uptimeHours,
-                    uptimeMinutes,
-                    uptimeSeconds,
-                    uptimeMilliseconds,
-                    ntripServerConnectionAttemptsTotal);
+                   uptimeDays,
+                   uptimeHours,
+                   uptimeMinutes,
+                   uptimeSeconds,
+                   uptimeMilliseconds,
+                   ntripServerConnectionAttemptsTotal);
     }
 
     if (settings.enableSD == true && online.microSD == true)
@@ -401,6 +401,74 @@ void menuSystem()
   clearBuffer(); //Empty buffer of any newline chars
 }
 
+//Set WiFi credentials
+//Enable TCP connections
+//TODO list networks
+//TODO change IP on config display to match AP or local IP
+void menuWiFi()
+{
+  while (1)
+  {
+    systemPrintln();
+    systemPrintln("Menu: WiFi Networks");
+
+    for (int x = 0 ; x < MAX_WIFI_NETWORKS ; x++)
+    {
+      systemPrintf("%d) SSID %d: %s\r\n", (x * 2) + 1, x + 1, settings.wifiNetworks[x].ssid);
+      systemPrintf("%d) Password %d: %s\r\n", (x * 2) + 2, x + 1, settings.wifiNetworks[x].password);
+    }
+
+    systemPrintf("%d) Configure device via WiFi Access Point or connect to WiFi: ", (MAX_WIFI_NETWORKS * 2) + 1);
+    if (settings.wifiConfigOverAP == true) systemPrintln("AP");
+    else systemPrintln("WiFi");
+
+    systemPrintln("x) Exit");
+
+    byte incoming = getCharacterNumber();
+
+    if (incoming >= 1 && incoming <= MAX_WIFI_NETWORKS * 2)
+    {
+      int arraySlot = ((incoming - 1) / 2); //Adjust incoming to array starting at 0
+
+      if (incoming % 2 == 1)
+      {
+        systemPrintf("Enter SSID network %d: ", arraySlot + 1);
+        getString(settings.wifiNetworks[arraySlot].ssid, sizeof(settings.wifiNetworks[arraySlot].ssid));
+        restartRover = true; //If we are modifying the SSID table, force restart of rover/base
+        restartBase = true;
+      }
+      else
+      {
+        systemPrintf("Enter Password for %s: ", settings.wifiNetworks[arraySlot].ssid);
+        getString(settings.wifiNetworks[arraySlot].password, sizeof(settings.wifiNetworks[arraySlot].password));
+        restartRover = true;
+        restartBase = true;
+      }
+    }
+    else if (incoming == (MAX_WIFI_NETWORKS * 2) + 1)
+    {
+      settings.wifiConfigOverAP ^= 1;
+    }
+    else if (incoming == 'x')
+      break;
+    else if (incoming == INPUT_RESPONSE_EMPTY)
+      break;
+    else if (incoming == INPUT_RESPONSE_GETCHARACTERNUMBER_TIMEOUT)
+      break;
+    else
+      printUnknown(incoming);
+  }
+
+  //Erase passwords from empty SSID entries
+  for (int x = 0 ; x < MAX_WIFI_NETWORKS ; x++)
+  {
+    if (strlen(settings.wifiNetworks[x].ssid) == 0)
+      strcpy(settings.wifiNetworks[x].password, "");
+  }
+
+  clearBuffer(); //Empty buffer of any newline chars
+}
+
 //Toggle control of heap reports and I2C GNSS debug
 void menuDebug()
 {
@@ -410,9 +478,9 @@ void menuDebug()
     systemPrintln("Menu: Debug");
 
     systemPrintf("Filtered by parser: %d NMEA / %d RTCM / %d UBX\n\r",
-                  failedParserMessages_NMEA,
-                  failedParserMessages_RTCM,
-                  failedParserMessages_UBX);
+                 failedParserMessages_NMEA,
+                 failedParserMessages_RTCM,
+                 failedParserMessages_UBX);
 
     systemPrint("1) u-blox I2C Debugging Output: ");
     if (settings.enableI2Cdebug == true) systemPrintln("Enabled");

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -589,6 +589,7 @@ typedef struct {
   };
 
   bool wifiConfigOverAP = true; //Configure device over Access Point or have it connect to WiFi 
+  uint16_t wifiTcpPort = 2947; //TCP port to use in Client/Server mode. 2947 is GPS Daemon: http://tcp-udp-ports.com/port-2947.htm
 
 } Settings;
 Settings settings;

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -200,6 +200,14 @@ enum LogTestState
 } ;
 uint8_t logTestState = LOGTEST_END;
 
+typedef struct WiFiNetwork
+{
+  char ssid[50];
+  char password[50];
+} WiFiNetwork;
+
+#define MAX_WIFI_NETWORKS 4
+
 typedef struct _PARSE_STATE * P_PARSE_STATE;
 
 //Parse routine
@@ -247,9 +255,9 @@ typedef enum
   INPUT_RESPONSE_GETNUMBER_EXIT = -9999999, //Less than min ECEF. User may be prompted for number but wants to exit without entering data
   INPUT_RESPONSE_GETNUMBER_TIMEOUT = -9999998,
   INPUT_RESPONSE_GETCHARACTERNUMBER_TIMEOUT = 255,
-  INPUT_RESPONSE_TIMEOUT = -2,
-  INPUT_RESPONSE_OVERFLOW = -1,
-  INPUT_RESPONSE_EMPTY = 0,
+  INPUT_RESPONSE_TIMEOUT = -3,
+  INPUT_RESPONSE_OVERFLOW = -2,
+  INPUT_RESPONSE_EMPTY = -1,
   INPUT_RESPONSE_VALID = 1,
 } InputResponse;
 
@@ -498,8 +506,6 @@ typedef struct {
   char ntripServer_CasterUserPW[50] = "";
   char ntripServer_MountPoint[50] = "bldr_dwntwn2"; //NTRIP Server
   char ntripServer_MountPointPW[50] = "WR5wRo4H";
-  char ntripServer_wifiSSID[50] = "TRex"; //NTRIP Server WiFi
-  char ntripServer_wifiPW[50] = "parachutes";
 
   //NTRIP Client
   bool enableNtripClient = false;
@@ -509,16 +515,12 @@ typedef struct {
   char ntripClient_CasterUserPW[50] = "";
   char ntripClient_MountPoint[50] = "bldr_SparkFun1";
   char ntripClient_MountPointPW[50] = "";
-  char ntripClient_wifiSSID[50] = "TRex"; //NTRIP Server WiFi
-  char ntripClient_wifiPW[50] = "parachutes";
   bool ntripClient_TransmitGGA = true;
 
   int16_t serialTimeoutGNSS = 1; //In ms - used during SerialGNSS.begin. Number of ms to pass of no data before hardware serial reports data available.
 
   char pointPerfectDeviceProfileToken[40] = "";
   bool enablePointPerfectCorrections = true;
-  char home_wifiSSID[50] = ""; //WiFi network to use when attempting to obtain PointPerfect keys and ThingStream provisioning
-  char home_wifiPW[50] = "";
   bool autoKeyRenewal = true; //Attempt to get keys if we get under 28 days from the expiration date
   char pointPerfectClientID[50] = "";
   char pointPerfectBrokerHost[50] = ""; // pp.services.u-blox.com
@@ -578,6 +580,16 @@ typedef struct {
   bool enablePrintBufferOverrun = false;
   bool enablePrintSDBuffers = false;
   bool forceResetOnSDFail = false; //Set to true to reset system if SD is detected but fails to start.
+
+  WiFiNetwork wifiNetworks[MAX_WIFI_NETWORKS] = {
+    {"", ""},
+    {"", ""},
+    {"", ""},
+    {"", ""},
+  };
+
+  bool wifiConfigOverAP = true; //Configure device over Access Point or have it connect to WiFi 
+
 } Settings;
 Settings settings;
 const Settings defaultSettings = Settings();

--- a/Firmware/RTK_Surveyor/support.ino
+++ b/Firmware/RTK_Surveyor/support.ino
@@ -78,7 +78,7 @@ void systemPrintf(const char* format, ...) {
 void systemPrintln(const char* value)
 {
   systemPrint(value);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print an integer value
@@ -102,11 +102,28 @@ void systemPrint(int value, uint8_t printType)
   systemPrint(temp);
 }
 
+//Pretty print IP addresses
+void systemPrint(IPAddress ipaddress)
+{
+  systemPrint(ipaddress[0], DEC);
+  systemPrint(".");
+  systemPrint(ipaddress[1], DEC);
+  systemPrint(".");
+  systemPrint(ipaddress[2], DEC);
+  systemPrint(".");
+  systemPrint(ipaddress[3], DEC);
+}
+void systemPrintln(IPAddress ipaddress)
+{
+  systemPrint(ipaddress);
+  systemPrintln();
+}
+
 //Print an integer value with a carriage return and line feed
 void systemPrintln(int value)
 {
   systemPrint(value);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print an 8-bit value as HEX or decimal
@@ -126,7 +143,7 @@ void systemPrint(uint8_t value, uint8_t printType)
 void systemPrintln(uint8_t value, uint8_t printType)
 {
   systemPrint(value, printType);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print a 16-bit value as HEX or decimal
@@ -146,7 +163,7 @@ void systemPrint(uint16_t value, uint8_t printType)
 void systemPrintln(uint16_t value, uint8_t printType)
 {
   systemPrint(value, printType);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print a floating point value with a specified number of decimal places
@@ -162,7 +179,7 @@ void systemPrint(float value, uint8_t decimals)
 void systemPrintln(float value, uint8_t decimals)
 {
   systemPrint(value, decimals);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print a double precision floating point value with a specified number of decimal places
@@ -178,20 +195,18 @@ void systemPrint(double value, uint8_t decimals)
 void systemPrintln(double value, uint8_t decimals)
 {
   systemPrint(value, decimals);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print a string
 void systemPrint(String myString)
 {
-  char temp[300];
-  myString.toCharArray(temp, sizeof(temp));
-  systemPrint(temp);
+  systemPrint(myString.c_str());
 }
 void systemPrintln(String myString)
 {
   systemPrint(myString);
-  systemPrint("\r\n");
+  systemPrintln();
 }
 
 //Print a carriage return and linefeed
@@ -199,8 +214,6 @@ void systemPrintln()
 {
   systemPrint("\r\n");
 }
-
-
 
 //Option not known
 void printUnknown(uint8_t unknownChoice)


### PR DESCRIPTION
This PR:

* Consolidates NTRIP Client, NTRIP Server, and PointPerfect Home WiFi/PW credentials into a single list of up to four networks. All four networks are attempted when WiFi is needed, and the best network is automatically used. 
* Add a WiFi menu to serial config and to the WiFi AP config page.
* Add TCP server and client controls to AP config page. Fix for #358.
* Make TCP port user configurable. Add to AP config page.
* Add option to allow WiFi configure over local WiFi (as opposed to AP).
* Change how IP addresses are shown on display.