### PR TITLE
Add information on iOS BLE to Bluetooth Page

### DIFF
--- a/docs/connecting_bluetooth.md
+++ b/docs/connecting_bluetooth.md
@@ -59,3 +59,9 @@ The device is now paired and a series of COM ports will be added under 'Device M
 *NMEA received over the Bluetooth COM port*
 
 If necessary, you can open a terminal connection to one of the COM ports. Because the Bluetooth driver creates multiple COM ports, it's impossible to tell which is the serial stream so it's easiest to just try each port until you see a stream of NMEA sentences (shown above). You're all set! Be sure to close out the terminal window so that other software can use that COM port.
+
+*Apple iOS*
+
+Apple products do not support Bluetooth SPP. That's ok! The SparkFun RTK devices support Bluetooth Low Energy (BLE) which does work with iOS.
+
+More information is available on the [System Menu](https://docs.sparkfun.com/SparkFun_RTK_Firmware/menu_system/) for switching between Bluetooth SPP and BLE.


### PR DESCRIPTION
I got stuck here for half a day trying to configure the device to work with my iPhone.  I couldn't understand why it wouldn't pair with my phone when it paired just fine with my computer.  Finally I read ahead in the instructions and at the very bottom of the GIS software page I found this nugget of information.  I almost missed it since most of the GIS software was not relevant to me.  I recommend moving this nugget of information up a page so others don't get stuck here quite so easily.