### PR TITLE
Add Ethernet / WiFi fail-over support

### DIFF
--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -651,9 +651,8 @@ void createSettingsString(char *newSettings)
     stringRecord(newSettings, "ntripClient_MountPointPW", settings.ntripClient_MountPointPW);
     stringRecord(newSettings, "ntripClient_TransmitGGA", settings.ntripClient_TransmitGGA);
 
-    // stringRecord(newSettings, "ntripServerUseWiFiNotEthernet", settings.ntripServerUseWiFiNotEthernet); //For future
-    // expansion stringRecord(newSettings, "ntripClientUseWiFiNotEthernet", settings.ntripClientUseWiFiNotEthernet);
-    // //For future expansion
+    stringRecord(newSettings, "ntripServerUseWiFiNotEthernet", settings.ntripServerUseWiFiNotEthernet);
+    stringRecord(newSettings, "ntripClientUseWiFiNotEthernet", settings.ntripClientUseWiFiNotEthernet);
 
     // Sensor Fusion Config
     stringRecord(newSettings, "enableSensorFusion", settings.enableSensorFusion);
@@ -1162,11 +1161,10 @@ void updateSettingWithValue(const char *settingName, const char *settingValueStr
     else if (strcmp(settingName, "ntripClient_TransmitGGA") == 0)
         settings.ntripClient_TransmitGGA = settingValueBool;
 
-    // For future expansion
-    // else if (strcmp(settingName, "ntripServerUseWiFiNotEthernet") == 0)
-    //   settings.ntripServerUseWiFiNotEthernet = settingValueBool;
-    // else if (strcmp(settingName, "ntripClientUseWiFiNotEthernet") == 0)
-    //   settings.ntripClientUseWiFiNotEthernet = settingValueBool;
+    else if (strcmp(settingName, "ntripServerUseWiFiNotEthernet") == 0)
+        settings.ntripServerUseWiFiNotEthernet = settingValueBool;
+    else if (strcmp(settingName, "ntripClientUseWiFiNotEthernet") == 0)
+        settings.ntripClientUseWiFiNotEthernet = settingValueBool;
 
     else if (strcmp(settingName, "serialTimeoutGNSS") == 0)
         settings.serialTimeoutGNSS = settingValue;

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -652,7 +652,9 @@ void createSettingsString(char *newSettings)
     stringRecord(newSettings, "ntripClient_TransmitGGA", settings.ntripClient_TransmitGGA);
 
     stringRecord(newSettings, "ntripServerUseWiFiNotEthernet", settings.ntripServerUseWiFiNotEthernet);
+    stringRecord(newSettings, "ntripServerEnableNetworkFailOver", settings.ntripServerEnableNetworkFailOver);
     stringRecord(newSettings, "ntripClientUseWiFiNotEthernet", settings.ntripClientUseWiFiNotEthernet);
+    stringRecord(newSettings, "ntripClientEnableNetworkFailOver", settings.ntripClientEnableNetworkFailOver);
 
     // Sensor Fusion Config
     stringRecord(newSettings, "enableSensorFusion", settings.enableSensorFusion);
@@ -1163,8 +1165,12 @@ void updateSettingWithValue(const char *settingName, const char *settingValueStr
 
     else if (strcmp(settingName, "ntripServerUseWiFiNotEthernet") == 0)
         settings.ntripServerUseWiFiNotEthernet = settingValueBool;
+    else if (strcmp(settingName, "ntripServerEnableNetworkFailOver") == 0)
+        settings.ntripServerEnableNetworkFailOver = settingValueBool;
     else if (strcmp(settingName, "ntripClientUseWiFiNotEthernet") == 0)
         settings.ntripClientUseWiFiNotEthernet = settingValueBool;
+    else if (strcmp(settingName, "ntripClientEnableNetworkFailOver") == 0)
+        settings.ntripClientEnableNetworkFailOver = settingValueBool;
 
     else if (strcmp(settingName, "serialTimeoutGNSS") == 0)
         settings.serialTimeoutGNSS = settingValue;

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -250,8 +250,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     settingsFile->printf("%s=%s\r\n", "ntripServer_CasterUserPW", settings.ntripServer_CasterUserPW);
     settingsFile->printf("%s=%s\r\n", "ntripServer_MountPoint", settings.ntripServer_MountPoint);
     settingsFile->printf("%s=%s\r\n", "ntripServer_MountPointPW", settings.ntripServer_MountPointPW);
-    // settingsFile->printf("%s=%d\r\n", "ntripServerUseWiFiNotEthernet", settings.ntripServerUseWiFiNotEthernet); //For
-    // future expansion
+    settingsFile->printf("%s=%d\r\n", "ntripServerUseWiFiNotEthernet", settings.ntripServerUseWiFiNotEthernet);
     settingsFile->printf("%s=%d\r\n", "enableNtripClient", settings.enableNtripClient);
     settingsFile->printf("%s=%s\r\n", "ntripClient_CasterHost", settings.ntripClient_CasterHost);
     settingsFile->printf("%s=%d\r\n", "ntripClient_CasterPort", settings.ntripClient_CasterPort);
@@ -260,8 +259,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     settingsFile->printf("%s=%s\r\n", "ntripClient_MountPoint", settings.ntripClient_MountPoint);
     settingsFile->printf("%s=%s\r\n", "ntripClient_MountPointPW", settings.ntripClient_MountPointPW);
     settingsFile->printf("%s=%d\r\n", "ntripClient_TransmitGGA", settings.ntripClient_TransmitGGA);
-    // settingsFile->printf("%s=%d\r\n", "ntripClientUseWiFiNotEthernet", settings.ntripClientUseWiFiNotEthernet); //For
-    // future expansion
+    settingsFile->printf("%s=%d\r\n", "ntripClientUseWiFiNotEthernet", settings.ntripClientUseWiFiNotEthernet);
     settingsFile->printf("%s=%d\r\n", "serialTimeoutGNSS", settings.serialTimeoutGNSS);
     settingsFile->printf("%s=%s\r\n", "pointPerfectDeviceProfileToken", settings.pointPerfectDeviceProfileToken);
     settingsFile->printf("%s=%d\r\n", "enablePointPerfectCorrections", settings.enablePointPerfectCorrections);
@@ -1006,9 +1004,8 @@ bool parseLine(char *str, Settings *settings)
         strcpy(settings->ntripServer_MountPoint, settingValue);
     else if (strcmp(settingName, "ntripServer_MountPointPW") == 0)
         strcpy(settings->ntripServer_MountPointPW, settingValue);
-    // For future expansion
-    // else if (strcmp(settingName, "ntripServerUseWiFiNotEthernet") == 0)
-    //   settings->ntripServerUseWiFiNotEthernet = d;
+    else if (strcmp(settingName, "ntripServerUseWiFiNotEthernet") == 0)
+        settings->ntripServerUseWiFiNotEthernet = d;
     else if (strcmp(settingName, "enableNtripClient") == 0)
         settings->enableNtripClient = d;
     else if (strcmp(settingName, "ntripClient_CasterHost") == 0)
@@ -1025,9 +1022,8 @@ bool parseLine(char *str, Settings *settings)
         strcpy(settings->ntripClient_MountPointPW, settingValue);
     else if (strcmp(settingName, "ntripClient_TransmitGGA") == 0)
         settings->ntripClient_TransmitGGA = d;
-    // For future expansion
-    // else if (strcmp(settingName, "ntripClientUseWiFiNotEthernet") == 0)
-    //   settings->ntripClientUseWiFiNotEthernet = d;
+    else if (strcmp(settingName, "ntripClientUseWiFiNotEthernet") == 0)
+        settings->ntripClientUseWiFiNotEthernet = d;
     else if (strcmp(settingName, "serialTimeoutGNSS") == 0)
         settings->serialTimeoutGNSS = d;
     else if (strcmp(settingName, "pointPerfectDeviceProfileToken") == 0)

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -251,6 +251,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     settingsFile->printf("%s=%s\r\n", "ntripServer_MountPoint", settings.ntripServer_MountPoint);
     settingsFile->printf("%s=%s\r\n", "ntripServer_MountPointPW", settings.ntripServer_MountPointPW);
     settingsFile->printf("%s=%d\r\n", "ntripServerUseWiFiNotEthernet", settings.ntripServerUseWiFiNotEthernet);
+    settingsFile->printf("%s=%d\r\n", "ntripServerEnableNetworkFailOver", settings.ntripServerEnableNetworkFailOver);
     settingsFile->printf("%s=%d\r\n", "enableNtripClient", settings.enableNtripClient);
     settingsFile->printf("%s=%s\r\n", "ntripClient_CasterHost", settings.ntripClient_CasterHost);
     settingsFile->printf("%s=%d\r\n", "ntripClient_CasterPort", settings.ntripClient_CasterPort);
@@ -260,6 +261,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     settingsFile->printf("%s=%s\r\n", "ntripClient_MountPointPW", settings.ntripClient_MountPointPW);
     settingsFile->printf("%s=%d\r\n", "ntripClient_TransmitGGA", settings.ntripClient_TransmitGGA);
     settingsFile->printf("%s=%d\r\n", "ntripClientUseWiFiNotEthernet", settings.ntripClientUseWiFiNotEthernet);
+    settingsFile->printf("%s=%d\r\n", "ntripClientEnableNetworkFailOver", settings.ntripClientEnableNetworkFailOver);
     settingsFile->printf("%s=%d\r\n", "serialTimeoutGNSS", settings.serialTimeoutGNSS);
     settingsFile->printf("%s=%s\r\n", "pointPerfectDeviceProfileToken", settings.pointPerfectDeviceProfileToken);
     settingsFile->printf("%s=%d\r\n", "enablePointPerfectCorrections", settings.enablePointPerfectCorrections);
@@ -1006,6 +1008,8 @@ bool parseLine(char *str, Settings *settings)
         strcpy(settings->ntripServer_MountPointPW, settingValue);
     else if (strcmp(settingName, "ntripServerUseWiFiNotEthernet") == 0)
         settings->ntripServerUseWiFiNotEthernet = d;
+    else if (strcmp(settingName, "ntripServerEnableNetworkFailOver") == 0)
+        settings->ntripServerEnableNetworkFailOver = d;
     else if (strcmp(settingName, "enableNtripClient") == 0)
         settings->enableNtripClient = d;
     else if (strcmp(settingName, "ntripClient_CasterHost") == 0)
@@ -1024,6 +1028,8 @@ bool parseLine(char *str, Settings *settings)
         settings->ntripClient_TransmitGGA = d;
     else if (strcmp(settingName, "ntripClientUseWiFiNotEthernet") == 0)
         settings->ntripClientUseWiFiNotEthernet = d;
+    else if (strcmp(settingName, "ntripClientEnableNetworkFailOver") == 0)
+        settings->ntripClientEnableNetworkFailOver = d;
     else if (strcmp(settingName, "serialTimeoutGNSS") == 0)
         settings->serialTimeoutGNSS = d;
     else if (strcmp(settingName, "pointPerfectDeviceProfileToken") == 0)

--- a/Firmware/RTK_Surveyor/NetworkClient.h
+++ b/Firmware/RTK_Surveyor/NetworkClient.h
@@ -169,10 +169,12 @@ class NetworkClient : public Client
         return 0;
     }
 
-  protected:
-
     bool _useWiFiNotEthernet;
-    Client * _client; // Ethernet or WiFi client
+    bool _enableFailOver;
+
+  protected:
+    
+    Client *_client; // Ethernet or WiFi client
 
     //------------------------------
     // Return the IP address

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -334,7 +334,6 @@ void ntripClientStop(bool clientAllocated)
                         No                Yes
     */
 
-#if defined(COMPILE_WIFI) || defined(COMPILE_ETHERNET)
     bool enableFailOver;
     bool useWiFiNotEthernet;
 
@@ -369,7 +368,7 @@ void ntripClientStop(bool clientAllocated)
 #endif //COMPILE_WIFI && COMPILE_ETHERNET
 
         // Allocate the NTRIP client structure if not done
-        if (wifiClientAllocated == false)
+        if (clientAllocated == false)
             ntripClient = new NTRIPClient(useWiFiNotEthernet, enableFailOver);
     }
 

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -475,11 +475,7 @@ void ntripClientUpdate()
             {
                 // NTRIP web service did not respond
                 if (ntripClientConnectLimitReached()) // Updates ntripClientConnectionAttemptTimeout
-                {
                     systemPrintln("NTRIP Caster failed to respond. Do you have your caster address and port correct?");
-
-                    // Stop NTRIP client operations
-                    ntripClientStop(true); // Do not allocate new ntripClient
                 }
                 else
                 {
@@ -489,9 +485,6 @@ void ntripClientUpdate()
                     else
                         systemPrintf("NTRIP Client failed to connect to caster. Trying again in %d minutes.\r\n",
                                      ntripClientConnectionAttemptTimeout / 1000 / 60);
-
-                    // Restart network operation after delay
-                    ntripClientStop(false);
                 }
             }
         }

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -374,7 +374,7 @@ void ntripClientUpdate()
 
     // Start the network
     case NTRIP_CLIENT_ON: {
-        if (HAS_ETHERNET) // && !settings.ntripClientUseWiFiNotEthernet) //For future expansion
+        if (HAS_ETHERNET && !settings.ntripClientUseWiFiNotEthernet)
         {
             if (online.ethernetStatus == ETH_NOT_STARTED)
             {

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -547,7 +547,6 @@ void ntripClientUpdate()
                 // NTRIP web service did not respond
                 if (ntripClientConnectLimitReached()) // Updates ntripClientConnectionAttemptTimeout
                     systemPrintln("NTRIP Caster failed to respond. Do you have your caster address and port correct?");
-                }
                 else
                 {
                     if (ntripClientConnectionAttemptTimeout / 1000 < 120)

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -373,7 +373,7 @@ void ntripServerUpdate()
 
     // Start the network
     case NTRIP_SERVER_ON:
-        if (HAS_ETHERNET) // && !settings.ntripServerUseWiFiNotEthernet) //For future expansion
+        if (HAS_ETHERNET&& (!settings.ntripServerUseWiFiNotEthernet))
         {
             if (online.ethernetStatus == ETH_NOT_STARTED)
             {

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -304,8 +304,64 @@ void ntripServerStart()
 // Stop the NTRIP server
 void ntripServerStop(bool clientAllocated)
 {
+    /*
+                        Wait Network needed <----------------.
+                                 |                           |
+                                 V                           |
+             .------------ HAS_ETHERNET                      |
+             |          No       | Yes                       |
+             V                   V                           |
+             +<------- xxxUseWiFiNotEthernet                 |
+             |     Yes           | No                        |
+             |                   V                           |
+             |       .---------->+<--------------------------)-------.
+             |       |           | UseWiFi=false             |       |
+             |       |           V                           |       |
+             |       |        Link Up ---------------.       |       |
+             |       |       Yes |    No             |       |       |
+             |       |           V                   |       |       |
+             |       |     Use Ethernet              |       |       |
+             |       |           | Failure or Off    |       |       |
+             |       |           V                   |       |       |
+             |       |           +<------------------'       |       |
+             |       |           V                           |       |
+             |       |     Is Network Off ------------------>+       |
+             |       |           | No     Yes                ^       |
+             |       |           V                           |       |
+             |       '---- enableFailOver                    |       |
+             |          No       | Yes                       |       |
+             V                   V                           |       |
+             +------------------>+                           |       |
+             ^                   | UseWifi=true              |       |
+             |                   V                           |       |
+             |       .--- WiFi Configured                    |       |
+             |       | No        | Yes                       |       |
+             |       |           V                           |       |
+             |       |        Use WiFi                       |       |
+             |       |           | Failure or Off            |       |
+             |       |           V                           |       |
+             |       '---------->+                           |       |
+             |                   V                           |       |
+             |             Is Network Off -------------------'       |
+             |                   | No     Yes                        |
+             |                   V                                   |
+             +<----------- HAS_ETHERNET                              |
+             ^          No       | Yes                               |
+             |                   V                                   |
+             '------------ enableFailOver ---------------------------'
+                        No                Yes
+    */
+
+#if defined(COMPILE_WIFI) || defined(COMPILE_ETHERNET)
+    bool enableFailOver;
+    bool useWiFiNotEthernet;
+
     if (ntripServer)
     {
+        //Save the previous network state
+        enableFailOver = ntripServer->_enableFailOver;
+        useWiFiNotEthernet = ntripServer->_useWiFiNotEthernet;
+
         // Break the NTRIP server connection if necessary
         if (ntripServer->connected())
             ntripServer->stop();
@@ -314,9 +370,25 @@ void ntripServerStop(bool clientAllocated)
         delete ntripServer;
         ntripServer = nullptr;
 
-        // Allocate the ntripServer structure if not done
-        if (clientAllocated == false)
-            ntripServer = new NetworkClient(false);
+#if defined(COMPILE_WIFI) && defined(COMPILE_ETHERNET)
+        //Determine the next network adapter to use
+        if ((!useWiFiNotEthernet) && enableFailOver) //Was using Ethernet, switch to WiFi
+        {
+            if (settings.enablePrintEthernetDiag)
+              systemPrintln("Failing over from Ethernet to WiFi");
+            useWiFiNotEthernet = true;
+        }
+        else if (useWiFiNotEthernet && HAS_ETHERNET && enableFailOver) //Was using WiFi, switch to Ethernet
+        {
+            if (settings.enablePrintEthernetDiag)
+              systemPrintln("Failing over from WiFi to Ethernet");
+            useWiFiNotEthernet = false;
+        }
+#endif //COMPILE_WIFI && COMPILE_ETHERNET
+
+        // Allocate the NTRIP server structure if not done
+        if (wifiClientAllocated == false)
+            ntripServer = new NTRIPClient(useWiFiNotEthernet, enableFailOver);
     }
 
     // Increase timeouts if we started the network
@@ -373,7 +445,7 @@ void ntripServerUpdate()
 
     // Start the network
     case NTRIP_SERVER_ON:
-        if (HAS_ETHERNET&& (!settings.ntripServerUseWiFiNotEthernet))
+        if (HAS_ETHERNET && (!ntripServer->_useWiFiNotEthernet))
         {
             if (online.ethernetStatus == ETH_NOT_STARTED)
             {
@@ -424,7 +496,7 @@ void ntripServerUpdate()
         if ((millis() - ntripServerTimer) > (1 * 60 * 1000))
             // Failed to connect to to the network, attempt to restart the network
             ntripServerStop(false);
-        else if (HAS_ETHERNET) // && !settings.ntripServerUseWiFiNotEthernet) //For future expansion
+        else if (HAS_ETHERNET && (!ntripServer->_useWiFiNotEthernet))
         {
             if (online.ethernetStatus == ETH_CONNECTED)
                 ntripServerSetState(NTRIP_SERVER_NETWORK_CONNECTED);

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -497,9 +497,6 @@ void ntripServerUpdate()
                     else
                         systemPrintf("NTRIP caster failed to respond. Trying again in %d minutes.\r\n",
                                      ntripServerConnectionAttemptTimeout / 1000 / 60);
-
-                    // Restart network operation after delay
-                    ntripServerStop(false);
                 }
             }
         }

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -352,7 +352,6 @@ void ntripServerStop(bool clientAllocated)
                         No                Yes
     */
 
-#if defined(COMPILE_WIFI) || defined(COMPILE_ETHERNET)
     bool enableFailOver;
     bool useWiFiNotEthernet;
 
@@ -387,7 +386,7 @@ void ntripServerStop(bool clientAllocated)
 #endif //COMPILE_WIFI && COMPILE_ETHERNET
 
         // Allocate the NTRIP server structure if not done
-        if (wifiClientAllocated == false)
+        if (clientAllocated == false)
             ntripServer = new NTRIPClient(useWiFiNotEthernet, enableFailOver);
     }
 

--- a/Firmware/RTK_Surveyor/menuBase.ino
+++ b/Firmware/RTK_Surveyor/menuBase.ino
@@ -110,13 +110,14 @@ void menuBase()
                 systemPrintf("%s\r\n", settings.ntripServer_StartAtSurveyIn ? "WiFi" : "Bluetooth");
             }
 
-            // For future expansion
-            // if (HAS_ETHERNET)
-            //{
-            //   systemPrintf("14) Use WiFi (not Ethernet) for NTRIP Server: ", menuEntry++);
-            //   if (settings.ntripServerUseWiFiNotEthernet == true) systemPrintln("Enabled");
-            //   else systemPrintln("Disabled");
-            // }
+            if (HAS_ETHERNET)
+            {
+                systemPrintf("14) Use WiFi (not Ethernet) for NTRIP Server: ");
+                if (settings.ntripServerUseWiFiNotEthernet == true)
+                    systemPrintln("Enabled");
+                else
+                    systemPrintln("Disabled");
+            }
         }
         else
         {
@@ -333,12 +334,11 @@ void menuBase()
             settings.ntripServer_StartAtSurveyIn ^= 1;
             restartBase = true;
         }
-        // For future expansion
-        // else if (incoming == 14 && settings.enableNtripServer == true && HAS_ETHERNET)
-        //{
-        //   settings.ntripServerUseWiFiNotEthernet ^= 1;
-        //   restartBase = true;
-        // }
+        else if (incoming == 14 && settings.enableNtripServer == true && HAS_ETHERNET)
+        {
+            settings.ntripServerUseWiFiNotEthernet ^= 1;
+            restartBase = true;
+        }
         else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
             break;
         else if (incoming == INPUT_RESPONSE_GETNUMBER_TIMEOUT)

--- a/Firmware/RTK_Surveyor/menuBase.ino
+++ b/Firmware/RTK_Surveyor/menuBase.ino
@@ -112,8 +112,14 @@ void menuBase()
 
             if (HAS_ETHERNET)
             {
-                systemPrintf("14) Use WiFi (not Ethernet) for NTRIP Server: ");
+                systemPrintf("14) Default to WiFi (not Ethernet) for NTRIP Server: ");
                 if (settings.ntripServerUseWiFiNotEthernet == true)
+                    systemPrintln("Enabled");
+                else
+                    systemPrintln("Disabled");
+
+                systemPrintf("15) Enable fail over between Ethernet and WiFi for NTRIP Server: ");
+                if (settings.ntripServerEnableNetworkFailOver == true)
                     systemPrintln("Enabled");
                 else
                     systemPrintln("Disabled");
@@ -338,6 +344,10 @@ void menuBase()
         {
             settings.ntripServerUseWiFiNotEthernet ^= 1;
             restartBase = true;
+        }
+        else if (incoming == 15 && settings.enableNtripServer == true && HAS_ETHERNET)
+        {
+            settings.ntripServerEnableNetworkFailOver ^= 1;
         }
         else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
             break;

--- a/Firmware/RTK_Surveyor/menuEthernet.ino
+++ b/Firmware/RTK_Surveyor/menuEthernet.ino
@@ -8,16 +8,18 @@ bool ethernetIsNeeded()
         return true;
 
     // Does Base mode NTRIP Server need Ethernet?
-    if (HAS_ETHERNET && settings.enableNtripServer == true &&
-        (systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING)
-        //&& !settings.ntripServerUseWiFiNotEthernet //For future expansion
+    if (HAS_ETHERNET && (settings.enableNtripServer == true)
+        && (systemState >= STATE_BASE_NOT_STARTED)
+        && (systemState <= STATE_BASE_FIXED_TRANSMITTING)
+        && (!settings.ntripServerUseWiFiNotEthernet)
     )
         return true;
 
     // Does Rover mode NTRIP Client need Ethernet?
-    if (HAS_ETHERNET && settings.enableNtripClient == true &&
-        (systemState >= STATE_ROVER_NOT_STARTED && systemState <= STATE_ROVER_RTK_FIX)
-        //&& !settings.ntripClientUseWiFiNotEthernet //For future expansion
+    if (HAS_ETHERNET && (settings.enableNtripClient == true)
+        && (systemState >= STATE_ROVER_NOT_STARTED)
+        && (systemState <= STATE_ROVER_RTK_FIX)
+        && (!settings.ntripClientUseWiFiNotEthernet)
     )
         return true;
 

--- a/Firmware/RTK_Surveyor/menuGNSS.ino
+++ b/Firmware/RTK_Surveyor/menuGNSS.ino
@@ -108,13 +108,14 @@ void menuGNSS()
 
             systemPrintf("14) Minimum satellite signal level for navigation (dBHz): %d\r\n", minCNO);
 
-            // For future expansion
-            // if (HAS_ETHERNET)
-            //{
-            //   systemPrintf("15) Use WiFi (not Ethernet) for NTRIP Client: ", menuEntry++);
-            //   if (settings.ntripClientUseWiFiNotEthernet == true) systemPrintln("Enabled");
-            //   else systemPrintln("Disabled");
-            // }
+            if (HAS_ETHERNET)
+            {
+                systemPrintf("15) Use WiFi (not Ethernet) for NTRIP Client: ");
+                if (settings.ntripClientUseWiFiNotEthernet == true)
+                    systemPrintln("Enabled");
+                else
+                    systemPrintln("Disabled");
+            }
         }
         else
         {
@@ -307,12 +308,12 @@ void menuGNSS()
                 restartRover = true;
             }
         }
-        // For future expansion
-        // else if (incoming == 15 && settings.enableNtripClient == true && HAS_ETHERNET)
-        //{
-        //   settings.ntripClientUseWiFiNotEthernet ^= 1;
-        //   restartRover = true;
-        // }
+
+        else if (HAS_ETHERNET && (incoming == 15) && (settings.enableNtripClient == true))
+        {
+            settings.ntripClientUseWiFiNotEthernet ^= 1;
+            restartRover = true;
+        }
         else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
             break;
         else if (incoming == INPUT_RESPONSE_GETNUMBER_TIMEOUT)

--- a/Firmware/RTK_Surveyor/menuGNSS.ino
+++ b/Firmware/RTK_Surveyor/menuGNSS.ino
@@ -110,8 +110,14 @@ void menuGNSS()
 
             if (HAS_ETHERNET)
             {
-                systemPrintf("15) Use WiFi (not Ethernet) for NTRIP Client: ");
+                systemPrintf("15) Default to WiFi (not Ethernet) for NTRIP Client: ");
                 if (settings.ntripClientUseWiFiNotEthernet == true)
+                    systemPrintln("Enabled");
+                else
+                    systemPrintln("Disabled");
+
+                systemPrintf("16) Enable fail over between Ethernet and WiFi for NTRIP Client: ");
+                if (settings.ntripClientEnableNetworkFailOver == true)
                     systemPrintln("Enabled");
                 else
                     systemPrintln("Disabled");
@@ -313,6 +319,10 @@ void menuGNSS()
         {
             settings.ntripClientUseWiFiNotEthernet ^= 1;
             restartRover = true;
+        }
+        else if (HAS_ETHERNET && (incoming == 16) && (settings.enableNtripClient == true))
+        {
+            settings.ntripClientEnableNetworkFailOver ^= 1;
         }
         else if (incoming == INPUT_RESPONSE_GETNUMBER_EXIT)
             break;

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -800,6 +800,7 @@ typedef struct
     // ntripServerUseWiFiNotEthernet is set to true. Setting ntripServerUseWiFiNotEthernet to true will make
     // Ethernet-enabled products use WiFi for NTRIP Server instead.
     bool ntripServerUseWiFiNotEthernet = false;
+    bool ntripServerEnableNetworkFailOver = false; //When true enables fail over between Ethernet and WiFi if both networks are supported
 
     // NTRIP Client
     bool enableNtripClient = false;
@@ -814,6 +815,7 @@ typedef struct
     // Setting ntripClientUseWiFiNotEthernet to true will make Ethernet-enabled products use WiFi for NTRIP Client
     // instead.
     bool ntripClientUseWiFiNotEthernet = false;
+    bool ntripClientEnableNetworkFailOver = false; //When true enables fail over between Ethernet and WiFi if both networks are supported
 
     int16_t serialTimeoutGNSS = 1; // In ms - used during SerialGNSS.begin. Number of ms to pass of no data before
                                    // hardware serial reports data available.

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -798,8 +798,8 @@ typedef struct
     char ntripServer_MountPointPW[50] = "WR5wRo4H";
     // Products that have Ethernet will always use Ethernet for NTRIP Server and Client, unless
     // ntripServerUseWiFiNotEthernet is set to true. Setting ntripServerUseWiFiNotEthernet to true will make
-    // Ethernet-enabled products use WiFi for NTRIP Server instead. bool ntripServerUseWiFiNotEthernet = false; //For
-    // future expansion
+    // Ethernet-enabled products use WiFi for NTRIP Server instead.
+    bool ntripServerUseWiFiNotEthernet = false;
 
     // NTRIP Client
     bool enableNtripClient = false;
@@ -812,7 +812,8 @@ typedef struct
     char ntripClient_MountPointPW[50] = "";
     bool ntripClient_TransmitGGA = true;
     // Setting ntripClientUseWiFiNotEthernet to true will make Ethernet-enabled products use WiFi for NTRIP Client
-    // instead. bool ntripClientUseWiFiNotEthernet = false; //For future expansion
+    // instead.
+    bool ntripClientUseWiFiNotEthernet = false;
 
     int16_t serialTimeoutGNSS = 1; // In ms - used during SerialGNSS.begin. Number of ms to pass of no data before
                                    // hardware serial reports data available.


### PR DESCRIPTION
Add menu items:
* Select default for NTRIP Client: Ethernet or WiFi
* Select default for NTRIP Server: Ethernet or WiFi
* Enable / disable Ethernet / WiFi fail-over for NTRIP Client
* Enable / disable Ethernet / WiFi fail-over for NTRIP Server
* Save network selection and fail-over enable in NTRIPClient
* Pass in network selection and fail-over enable when creating NTRIPClient
* When network fails, get the previous network selection and fail-over enable
* When fail-over is enabled and network fails, toggle network selection