### PR TITLE
Use a consistent format for the version number

### DIFF
--- a/Firmware/RTK_Surveyor/Begin.ino
+++ b/Firmware/RTK_Surveyor/Begin.ino
@@ -230,8 +230,9 @@ void beginBoard()
         strncpy(platformPrefix, "Reference Station", sizeof(platformPrefix) - 1);
     }
 
-    systemPrintf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR,
-                 __DATE__);
+    char versionString[21];
+    getFirmwareVersion(versionString, sizeof(versionString), true);
+    systemPrintf("SparkFun RTK %s %s\r\n", platformPrefix, versionString);
 
     // Get unit MAC address
     esp_read_mac(wifiMACAddress, ESP_MAC_WIFI_STA);

--- a/Firmware/RTK_Surveyor/Display.ino
+++ b/Firmware/RTK_Surveyor/Display.ino
@@ -636,11 +636,7 @@ void displaySplash()
 
         yPos = yPos + fontHeight + 7;
         char unitFirmware[50];
-        if (ENABLE_DEVELOPER)
-            snprintf(unitFirmware, sizeof(unitFirmware), "v%d.%d-DEV", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR);
-        else
-            snprintf(unitFirmware, sizeof(unitFirmware), "v%d.%d", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR);
-
+        getFirmwareVersion(unitFirmware, sizeof(unitFirmware), false);
         printTextCenter(unitFirmware, yPos, QW_FONT_5X7, 1, false);
 
         oled.display();

--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -573,8 +573,7 @@ void createSettingsString(char *newSettings)
     stringRecord(newSettings, "platformPrefix", platformPrefix);
 
     char apRtkFirmwareVersion[86];
-    snprintf(apRtkFirmwareVersion, sizeof(apRtkFirmwareVersion), "v%d.%d-%s", FIRMWARE_VERSION_MAJOR,
-             FIRMWARE_VERSION_MINOR, __DATE__);
+    getFirmwareVersion(apRtkFirmwareVersion, sizeof(apRtkFirmwareVersion), true);
     stringRecord(newSettings, "rtkFirmwareVersion", apRtkFirmwareVersion);
 
     if (!configureViaEthernet) // ZED type is unknown if we are in configure-via-ethernet mode
@@ -1457,14 +1456,8 @@ void updateSettingWithValue(const char *settingName, const char *settingValueStr
         if (otaCheckVersion(reportedVersion, sizeof(reportedVersion)))
         {
             // We got a version number, now determine if it's newer or not
-            char currentVersion[20];
-            if (enableRCFirmware == false)
-                snprintf(currentVersion, sizeof(currentVersion), "%d.%d", FIRMWARE_VERSION_MAJOR,
-                         FIRMWARE_VERSION_MINOR);
-            else
-                snprintf(currentVersion, sizeof(currentVersion), "%d.%d-%s", FIRMWARE_VERSION_MAJOR,
-                         FIRMWARE_VERSION_MINOR, __DATE__);
-
+            char currentVersion[21];
+            getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
             if (isReportedVersionNewer(reportedVersion, currentVersion) == true)
             {
                 log_d("New version detected");

--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -193,8 +193,7 @@ void recordSystemSettingsToFile(File *settingsFile)
     settingsFile->printf("%s=%d\r\n", "rtkIdentifier", settings.rtkIdentifier);
 
     char firmwareVersion[30]; // v1.3 December 31 2021
-    snprintf(firmwareVersion, sizeof(firmwareVersion), "v%d.%d-%s", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR,
-             __DATE__);
+    getFirmwareVersion(firmwareVersion, sizeof(firmwareVersion), true);
     settingsFile->printf("%s=%s\r\n", "rtkFirmwareVersion", firmwareVersion);
 
     settingsFile->printf("%s=%s\r\n", "zedFirmwareVersion", zedFirmwareVersion);

--- a/Firmware/RTK_Surveyor/NtripClient.ino
+++ b/Firmware/RTK_Surveyor/NtripClient.ino
@@ -111,8 +111,11 @@ bool ntripClientConnect()
 
     // Set up the server request (GET)
     char serverRequest[SERVER_BUFFER_SIZE];
-    snprintf(serverRequest, SERVER_BUFFER_SIZE, "GET /%s HTTP/1.0\r\nUser-Agent: NTRIP SparkFun_RTK_%s_v%d.%d\r\n",
-             settings.ntripClient_MountPoint, platformPrefix, FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR);
+    int length;
+    snprintf(serverRequest, SERVER_BUFFER_SIZE, "GET /%s HTTP/1.0\r\nUser-Agent: NTRIP SparkFun_RTK_%s_\r\n",
+             settings.ntripClient_MountPoint, platformPrefix);
+    length = strlen(serverRequest);
+    getFirmwareVersion(&serverRequest[length], SERVER_BUFFER_SIZE - length, false);
 
     // Set up the credentials
     char credentials[CREDENTIALS_BUFFER_SIZE];

--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -111,9 +111,10 @@ bool ntripServerConnectCaster()
     //  * Mount point
     //  * Password
     //  * Agent
-    snprintf(serverBuffer, SERVER_BUFFER_SIZE, "SOURCE %s /%s\r\nSource-Agent: NTRIP SparkFun_RTK_%s/v%d.%d\r\n\r\n",
-             settings.ntripServer_MountPointPW, settings.ntripServer_MountPoint, platformPrefix, FIRMWARE_VERSION_MAJOR,
-             FIRMWARE_VERSION_MINOR);
+    snprintf(serverBuffer, SERVER_BUFFER_SIZE, "SOURCE %s /%s\r\nSource-Agent: NTRIP SparkFun_RTK_%s/\r\n\r\n",
+             settings.ntripServer_MountPointPW, settings.ntripServer_MountPoint, platformPrefix);
+    int length = strlen(serverBuffer);
+    getFirmwareVersion(&serverBuffer[length], sizeof(serverBuffer) - length, false);
 
     // Send the authorization credentials to the NTRIP caster
     ntripServer->write((const uint8_t *)serverBuffer, strlen(serverBuffer));

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -12,14 +12,9 @@ void menuFirmware()
         if (btPrintEcho == true)
             systemPrintln("Firmware update not available while configuration over Bluetooth is active");
 
-        char currentVersion[20];
-        if (enableRCFirmware == false)
-            snprintf(currentVersion, sizeof(currentVersion), "%d.%d", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR);
-        else
-            snprintf(currentVersion, sizeof(currentVersion), "%d.%d-%s", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR,
-                     __DATE__);
-
-        systemPrintf("Current firmware: v%s\r\n", currentVersion);
+        char currentVersion[21];
+        getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
+        systemPrintf("Current firmware: %s\r\n", currentVersion);
 
         if (strlen(reportedVersion) > 0)
         {
@@ -60,15 +55,9 @@ void menuFirmware()
                 if (otaCheckVersion(reportedVersion, sizeof(reportedVersion)))
                 {
                     // We got a version number, now determine if it's newer or not
-                    char currentVersion[20];
-                    if (enableRCFirmware == false)
-                        snprintf(currentVersion, sizeof(currentVersion), "%d.%d", FIRMWARE_VERSION_MAJOR,
-                                 FIRMWARE_VERSION_MINOR);
-                    else
-                        snprintf(currentVersion, sizeof(currentVersion), "%d.%d-%s", FIRMWARE_VERSION_MAJOR,
-                                 FIRMWARE_VERSION_MINOR, __DATE__);
-
-                    if (isReportedVersionNewer(reportedVersion, currentVersion) == true)
+                    char currentVersion[21];
+                    getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
+                    if (isReportedVersionNewer(reportedVersion, &currentVersion[1]) == true)
                     {
                         log_d("New version detected");
                         newOTAFirmwareAvailable = true;
@@ -97,15 +86,9 @@ void menuFirmware()
                     if (otaCheckVersion(reportedVersion, sizeof(reportedVersion)))
                     {
                         // We got a version number, now determine if it's newer or not
-                        char currentVersion[20];
-                        if (enableRCFirmware == false)
-                            snprintf(currentVersion, sizeof(currentVersion), "%d.%d", FIRMWARE_VERSION_MAJOR,
-                                     FIRMWARE_VERSION_MINOR);
-                        else
-                            snprintf(currentVersion, sizeof(currentVersion), "%d.%d-%s", FIRMWARE_VERSION_MAJOR,
-                                     FIRMWARE_VERSION_MINOR, __DATE__);
-
-                        if (isReportedVersionNewer(reportedVersion, currentVersion) == true)
+                        char currentVersion[21];
+                        getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
+                        if (isReportedVersionNewer(reportedVersion, &currentVersion[1]) == true)
                         {
                             log_d("New version detected");
                             newOTAFirmwareAvailable = true;
@@ -463,6 +446,39 @@ void updateFromSD(const char *firmwareFileName)
     systemPrintln("Firmware update failed. Please try again.");
 }
 
+// Format the firmware version
+void formatFirmwareVersion(uint8_t major, uint8_t minor, char * buffer, int bufferLength, bool includeDate)
+{
+    char prefix;
+
+    // Construct the full or release candidate version number
+    prefix = ENABLE_DEVELOPER ? 'd' : 'v';
+    if (enableRCFirmware && (bufferLength >= 21))
+        // 123456789012345678901
+        // pxxx.yyy-dd-mmm-yyyy0
+        snprintf(buffer, bufferLength, "%c%d.%d-%s", prefix, major, minor, __DATE__);
+
+    // Construct a truncated version number
+    else if (bufferLength >= 9)
+        // 123456789
+        // pxxx.yyy0
+        snprintf(buffer, bufferLength, "%c%d.%d", prefix, major, minor);
+
+    // The buffer is too small for the version number
+    else
+    {
+        systemPrintf("ERROR: Buffer too small for version number!\r\n");
+        if (bufferLength > 0)
+            *buffer = 0;
+    }
+}
+
+// Get the current firmware version
+void getFirmwareVersion(char * buffer, int bufferLength, bool includeDate)
+{
+    formatFirmwareVersion(FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, buffer, bufferLength, includeDate);
+}
+
 // Returns true if we successfully got the versionAvailable
 // Modifies versionAvailable with OTA getVersion response
 // Connects to WiFi as needed
@@ -474,14 +490,8 @@ bool otaCheckVersion(char *versionAvailable, uint8_t versionAvailableLength)
 
     if (wifiConnect(10000) == true)
     {
-        char versionString[20];
-
-        if (enableRCFirmware == false)
-            snprintf(versionString, sizeof(versionString), "%d.%d", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR);
-        else
-            snprintf(versionString, sizeof(versionString), "%d.%d-%s", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR,
-                     __DATE__);
-
+        char versionString[21];
+        getFirmwareVersion(versionString, sizeof(versionString), enableRCFirmware);
         systemPrintf("Current firmware version: v%s\r\n", versionString);
 
         if (enableRCFirmware == false)
@@ -546,16 +556,14 @@ void otaUpdate()
 
     if (wifiConnect(10000) == true)
     {
-        char versionString[20];
-        snprintf(versionString, sizeof(versionString), "%d.%d", 0, 0); // Force update with version 0.0
+        char versionString[9];
+        formatFirmwareVersion(0, 0, versionString, sizeof(versionString), false);
 
         ESP32OTAPull ota;
 
         int response;
-        if (enableRCFirmware == false)
-            response = ota.CheckForOTAUpdate(OTA_FIRMWARE_JSON_URL, versionString, ESP32OTAPull::DONT_DO_UPDATE);
-        else
-            response = ota.CheckForOTAUpdate(OTA_RC_FIRMWARE_JSON_URL, versionString, ESP32OTAPull::DONT_DO_UPDATE);
+        const char * url = enableRCFirmware ? OTA_RC_FIRMWARE_JSON_URL : OTA_FIRMWARE_JSON_URL;
+        response = ota.CheckForOTAUpdate(url, &versionString[1], ESP32OTAPull::DONT_DO_UPDATE);
 
         if (response == ESP32OTAPull::UPDATE_AVAILABLE)
         {

--- a/Firmware/RTK_Surveyor/menuMain.ino
+++ b/Firmware/RTK_Surveyor/menuMain.ino
@@ -26,12 +26,9 @@ void menuMain()
     while (1)
     {
         systemPrintln();
-        if (ENABLE_DEVELOPER)
-            systemPrintf("SparkFun RTK %s v%d.%d-RC-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR,
-                         FIRMWARE_VERSION_MINOR, __DATE__);
-        else
-            systemPrintf("SparkFun RTK %s v%d.%d-%s\r\n", platformPrefix, FIRMWARE_VERSION_MAJOR,
-                         FIRMWARE_VERSION_MINOR, __DATE__);
+        char versionString[21];
+        getFirmwareVersion(versionString, sizeof(versionString), true);
+        systemPrintf("SparkFun RTK %s %s\r\n", platformPrefix, versionString);
 
 #ifdef COMPILE_BT
         systemPrint("** Bluetooth broadcasting as: ");
@@ -341,7 +338,7 @@ void factoryReset(bool alreadyHasSemaphore)
     tasksStopUART2();
 
     // Attempt to write to file system. This avoids collisions with file writing from other functions like
-    // recordSystemSettingsToFile() and F9PSerialReadTask() if (settings.enableSD && online.microSD) 
+    // recordSystemSettingsToFile() and F9PSerialReadTask() if (settings.enableSD && online.microSD)
     //Don't check settings.enableSD - it could be corrupt
     if (online.microSD)
     {

--- a/Firmware/RTK_Surveyor/menuMessages.ino
+++ b/Firmware/RTK_Surveyor/menuMessages.ino
@@ -604,8 +604,8 @@ void beginLogging(const char *customFileName)
 
                 // SparkFun RTK Express v1.10-Feb 11 2022
                 char firmwareVersion[30]; // v1.3 December 31 2021
-                snprintf(firmwareVersion, sizeof(firmwareVersion), "v%d.%d-%s", FIRMWARE_VERSION_MAJOR,
-                         FIRMWARE_VERSION_MINOR, __DATE__);
+                firmwareVersion[0] = 'v';
+                getFirmwareVersion(&firmwareVersion[1], sizeof(firmwareVersion) -1, true);
                 createNMEASentence(CUSTOM_NMEA_TYPE_SYSTEM_VERSION, nmeaMessage, sizeof(nmeaMessage),
                                    firmwareVersion); // textID, buffer, sizeOfBuffer, text
                 ubxFile->println(nmeaMessage);

--- a/Firmware/RTK_Surveyor/menuPP.ino
+++ b/Firmware/RTK_Surveyor/menuPP.ino
@@ -201,8 +201,9 @@ bool pointperfectProvisionDevice()
 #endif // WHITELISTED_ID
 
         char givenName[100];
-        snprintf(givenName, sizeof(givenName), "SparkFun RTK %s v%d.%d - %s", platformPrefix, FIRMWARE_VERSION_MAJOR,
-                 FIRMWARE_VERSION_MINOR, hardwareID); // Get ready for JSON
+        char versionString[9];
+        getFirmwareVersion(versionString, sizeof(versionString), false);
+        snprintf(givenName, sizeof(givenName), "SparkFun RTK %s %s - %s", platformPrefix, versionString, hardwareID); // Get ready for JSON
 
         StaticJsonDocument<256> pointPerfectAPIPost;
 


### PR DESCRIPTION
* Prefix of d when ENABLE_DEVELOPER is set
* Prefix of v for other versions