### PR TITLE
Bug Fix: Discard the oldest data in the ring buffer

### DIFF
--- a/Firmware/RTK_Surveyor/Tasks.ino
+++ b/Firmware/RTK_Surveyor/Tasks.ino
@@ -283,17 +283,16 @@ void processUart1Message(PARSE_STATE *parse, uint8_t type)
     space = availableHandlerSpace;
     use = settings.gnssHandlerBufferSize - space;
     consumer = (char *)slowConsumer;
-    if ((bytesToCopy > space) && (!inMainMenu))
+
+    // Account for this message
+    if (bytesToCopy <= space)
+        availableHandlerSpace -= bytesToCopy;
+    else if (!inMainMenu)
     {
         if (consumer)
             systemPrintf("%s is slow, ", consumer);
-        systemPrintf("%d bytes of %d in use\r\n", use, settings.gnssHandlerBufferSize);
-        systemPrintf("Ring buffer full: discarding %d bytes\r\n", bytesToCopy);
-        return;
+        systemPrintf("%d bytes of %d in use, discarding data!\r\n", use, settings.gnssHandlerBufferSize);
     }
-
-    // Account for this message
-    availableHandlerSpace -= bytesToCopy;
 
     // Fill the buffer to the end and then start at the beginning
     if ((dataHead + bytesToCopy) > settings.gnssHandlerBufferSize)


### PR DESCRIPTION
The previous behavior discarded the newest data and possibly corrupting the data streams for the all of the devices which are keeping up with their writes.
    
This fix wraps the buffer pointer for the slowest device, discarding and entire buffer worth of data and corrupting the data stream for the slowest device.  The data streams for the other devices are not impacted.