### PR TITLE
Bug fix: Shutdown UART2 tasks before changing the ring buffer size

### DIFF
--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -753,8 +753,14 @@ void menuDebug()
                     systemPrintln("Error: Queue size out of range");
                 else
                 {
+                    // Stop the UART2 tssks to prevent the system from crashing
+                    tasksStopUART2();
+
+                    // Update the buffer size
                     settings.gnssHandlerBufferSize = queSize; // Recorded to NVM and file
                     recordSystemSettings();
+
+                    // Reboot the system
                     ESP.restart();
                 }
             }


### PR DESCRIPTION
This prevents a system crash and possible corruption of the SD card