### PR TITLE
Captive Portal for easy configuration

### DIFF
--- a/Firmware/RTK_Surveyor/Form.ino
+++ b/Firmware/RTK_Surveyor/Form.ino
@@ -11,34 +11,47 @@ Form.ino
 
 bool websocketConnected = false;
 
-class CaptiveRequestHandler : public AsyncWebHandler {
-public:
-  //https://en.wikipedia.org/wiki/Captive_portal
-  String urls[5] = {"/hotspot-detect.html", "/library/test/success.html", "/generate_204", "/ncsi.txt", "/check_network_status.txt"};
-  CaptiveRequestHandler() {}
-  virtual ~CaptiveRequestHandler() {}
-
-  bool canHandle(AsyncWebServerRequest *request){
-    for(int i = 0; i<5; i++){
-      if(request->url().equals(urls[i]))
-        return true;
+class CaptiveRequestHandler : public AsyncWebHandler
+{
+  public:
+    // https://en.wikipedia.org/wiki/Captive_portal
+    String urls[5] = {"/hotspot-detect.html", "/library/test/success.html", "/generate_204", "/ncsi.txt",
+                      "/check_network_status.txt"};
+    CaptiveRequestHandler()
+    {
     }
-    return false;
-  }
+    virtual ~CaptiveRequestHandler()
+    {
+    }
 
-  //Provide a custom small site for redirecting the user to the config site
-  //HTTP redirect does not work and the relative links on the default config site do not work, because the phone is requesting a different server
-  void handleRequest(AsyncWebServerRequest *request) {
-    String logmessage = "Captive Portal Client:" + request->client()->remoteIP().toString() + " " + request->url();
-    systemPrintln(logmessage);
-    AsyncResponseStream *response = request->beginResponseStream("text/html");
-    response->print("<!DOCTYPE html><html><head><title>RTK Config</title></head><body>");
-    response->print("<div class='container'>");
-    response->printf("<div align='center' class='col-sm-12'><img src='http://%s/src/rtk-setup.png' alt='SparkFun RTK WiFi Setup'></div>", WiFi.softAPIP().toString().c_str());
-    response->printf("<div align='center'><h3>Configure your RTK receiver <a href='http://%s/'>here</a></h3></div>", WiFi.softAPIP().toString().c_str());
-    response->print("</div></body></html>");
-    request->send(response);
-  }
+    bool canHandle(AsyncWebServerRequest *request)
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            if (request->url().equals(urls[i]))
+                return true;
+        }
+        return false;
+    }
+
+    // Provide a custom small site for redirecting the user to the config site
+    // HTTP redirect does not work and the relative links on the default config site do not work, because the phone is
+    // requesting a different server
+    void handleRequest(AsyncWebServerRequest *request)
+    {
+        String logmessage = "Captive Portal Client:" + request->client()->remoteIP().toString() + " " + request->url();
+        systemPrintln(logmessage);
+        AsyncResponseStream *response = request->beginResponseStream("text/html");
+        response->print("<!DOCTYPE html><html><head><title>RTK Config</title></head><body>");
+        response->print("<div class='container'>");
+        response->printf("<div align='center' class='col-sm-12'><img src='http://%s/src/rtk-setup.png' alt='SparkFun "
+                         "RTK WiFi Setup'></div>",
+                         WiFi.softAPIP().toString().c_str());
+        response->printf("<div align='center'><h3>Configure your RTK receiver <a href='http://%s/'>here</a></h3></div>",
+                         WiFi.softAPIP().toString().c_str());
+        response->print("</div></body></html>");
+        request->send(response);
+    }
 };
 
 // Start webserver in AP mode
@@ -92,7 +105,7 @@ bool startWebServer(bool startWiFi = true, int httpPort = 80)
         }
 
         websocket->onEvent(onWsEvent);
-        webserver->addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER);//only when requested from AP
+        webserver->addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER); // only when requested from AP
         webserver->addHandler(websocket);
 
         // * index.html (not gz'd)
@@ -122,7 +135,8 @@ bool startWebServer(bool startWiFi = true, int httpPort = 80)
             handleUpload); // Run handleUpload function when any file is uploaded. Must be before server.on() calls.
 
         webserver->on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-            AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", index_html, sizeof(index_html));
+            AsyncWebServerResponse *response =
+                request->beginResponse_P(200, "text/html", index_html, sizeof(index_html));
             response->addHeader("Content-Encoding", "gzip");
             request->send(response);
         });
@@ -135,8 +149,8 @@ bool startWebServer(bool startWiFi = true, int httpPort = 80)
         });
 
         webserver->on("/src/bootstrap.bundle.min.js", HTTP_GET, [](AsyncWebServerRequest *request) {
-            AsyncWebServerResponse *response =
-                request->beginResponse_P(200, "text/javascript", bootstrap_bundle_min_js, sizeof(bootstrap_bundle_min_js));
+            AsyncWebServerResponse *response = request->beginResponse_P(200, "text/javascript", bootstrap_bundle_min_js,
+                                                                        sizeof(bootstrap_bundle_min_js));
             response->addHeader("Content-Encoding", "gzip");
             request->send(response);
         });
@@ -163,7 +177,8 @@ bool startWebServer(bool startWiFi = true, int httpPort = 80)
         });
 
         webserver->on("/src/main.js", HTTP_GET, [](AsyncWebServerRequest *request) {
-            AsyncWebServerResponse *response = request->beginResponse_P(200, "text/javascript", main_js, sizeof(main_js));
+            AsyncWebServerResponse *response =
+                request->beginResponse_P(200, "text/javascript", main_js, sizeof(main_js));
             response->addHeader("Content-Encoding", "gzip");
             request->send(response);
         });
@@ -380,7 +395,7 @@ static void handleFileManager(AsyncWebServerRequest *request)
         {
             fileExists = SD_MMC.exists(slashFileName);
         }
-#endif  // COMPILE_SD_MMC
+#endif // COMPILE_SD_MMC
 
         if (fileExists == false)
         {
@@ -458,7 +473,7 @@ static void handleFileManager(AsyncWebServerRequest *request)
 #ifdef COMPILE_SD_MMC
                 else
                     SD_MMC.remove(slashFileName);
-#endif  // COMPILE_SD_MMC
+#endif // COMPILE_SD_MMC
                 request->send(200, "text/plain", "Deleted File: " + String(fileName));
             }
             else
@@ -762,7 +777,7 @@ void createSettingsString(char *newSettings)
 #ifdef COMPILE_L_BAND
         int daysRemaining = daysFromEpoch(settings.pointPerfectNextKeyStart + settings.pointPerfectNextKeyDuration + 1);
         snprintf(apDaysRemaining, sizeof(apDaysRemaining), "%d", daysRemaining);
-#endif  // COMPILE_L_BAND
+#endif // COMPILE_L_BAND
     }
     else
         snprintf(apDaysRemaining, sizeof(apDaysRemaining), "No Keys");
@@ -1377,7 +1392,7 @@ void updateSettingWithValue(const char *settingName, const char *settingValueStr
             requestChangeState(STATE_ROVER_NOT_STARTED); // If update failed, return to Rover mode.
     }
     else if (strcmp(settingName, "factoryDefaultReset") == 0)
-        factoryReset(false); //We do not have the sdSemaphore
+        factoryReset(false); // We do not have the sdSemaphore
     else if (strcmp(settingName, "exitAndReset") == 0)
     {
         // Confirm receipt
@@ -1792,7 +1807,7 @@ void getFileList(String &returnText)
 
             root.close();
         }
-#endif  // COMPILE_SD_MMC
+#endif // COMPILE_SD_MMC
 
         xSemaphoreGive(sdCardSemaphore);
     }
@@ -1914,4 +1929,4 @@ void handleUpload(AsyncWebServerRequest *request, String filename, size_t index,
     }
 }
 
-#endif  // COMPILE_AP
+#endif // COMPILE_AP

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -221,6 +221,7 @@ unsigned int binBytesSent = 0;         // Tracks firmware bytes sent over WiFi O
 #include <WiFi.h>             //Built-in.
 #include <WiFiClientSecure.h> //Built-in.
 #include <WiFiMulti.h>        //Built-in.
+#include <DNSServer.h>        //Built-in.
 
 #include "esp_wifi.h" //Needed for esp_wifi_set_protocol()
 

--- a/Firmware/RTK_Surveyor/WiFi.ino
+++ b/Firmware/RTK_Surveyor/WiFi.ino
@@ -60,6 +60,10 @@ static unsigned long wifiDisplayTimer;
 // Last time the WiFi state was displayed
 static uint32_t lastWifiState;
 
+//DNS server for Captive Portal
+static DNSServer dnsServer;
+
+
 //----------------------------------------
 // WiFi Routines
 //----------------------------------------
@@ -242,6 +246,12 @@ bool wifiStartAP()
         }
         systemPrint("WiFi AP Started with IP: ");
         systemPrintln(WiFi.softAPIP());
+        
+        // Start DNS Server
+        if(dnsServer.start(53, "*", WiFi.softAPIP()) == false){
+            systemPrintln("WiFi DNS Server failed to start");
+            return (false);
+        };
     }
     else
     {
@@ -355,6 +365,9 @@ void wifiUpdate()
             wifiStop();
         break;
     }
+    //Process the next DNS request
+    dnsServer.processNextRequest();
+
 }
 
 // Starts the WiFi connection state machine (moves from WIFI_OFF to WIFI_CONNECTING)
@@ -406,6 +419,9 @@ void wifiStop()
             delay(5);
         systemPrintln("TCP Server offline");
     }
+
+    //Stop the DNS server
+    dnsServer.stop();
 
     // Stop the other network clients and then WiFi
     networkStop(NETWORK_TYPE_WIFI);


### PR DESCRIPTION
This pull request shows the configuration website as a [captive portal](https://en.wikipedia.org/wiki/Captive_portal) for reducing the number of steps required to configure the RTK receiver via the web interface.

Therefore it is required to run a DNS server on the ESP32 and intercept the automatic requsts by the connected mobile device. The intercepted request on the in the wiki defined URLs are answered by a additional AsyncWebHandler that provides a small website redirecting the user to the configuration web interface. This extra step is required, because a simple HTTP redirct did not work in testing and the default index.html did not request the configuration data correctly. 

Previously the user would connect to the WiFi AP, read the IP on the RTK Express screen, type the IP into the browser and configure the receiver. With this change, the user simply connects to the WiFi AP and is automatically directed to the configuration page without even without knowing what an IP address is.

The code is tested with a RTK Express and iOS/Android clients.