### PR TITLE
Network: Don't restart network with no users

### DIFF
--- a/Firmware/RTK_Surveyor/Network.ino
+++ b/Firmware/RTK_Surveyor/Network.ino
@@ -1035,7 +1035,6 @@ void networkTypeUpdate(uint8_t networkType)
             {
                 if (settings.debugNetworkLayer)
                     systemPrintf("Network shutting down %s, no users\r\n", networkName[network->type]);
-                networkRestartNetwork(network);
                 networkStop(network->type);
             }
 


### PR DESCRIPTION
Fix 7 second WiFi restart when NTRIP shuts down due to connection attempts exceeded.