### PR TITLE
NTRIP Server: Add zedBytesSent value

### DIFF
--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -379,6 +379,8 @@ void ntripServerPrintStatus ()
 // This function gets called as each RTCM byte comes in
 void ntripServerProcessRTCM(uint8_t incoming)
 {
+    static uint32_t zedBytesSent;
+
     if (ntripServerState == NTRIP_SERVER_CASTING)
     {
         // Generate and print timestamp if needed
@@ -400,7 +402,8 @@ void ntripServerProcessRTCM(uint8_t incoming)
                 struct tm timeinfo = rtc.getTimeStruct();
                 char timestamp[30];
                 strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", &timeinfo);
-                systemPrintf("    Tx RTCM: %s.%03ld, %d bytes sent\r\n", timestamp, rtc.getMillis(), ntripServerBytesSent);
+                systemPrintf("    Tx RTCM: %s.%03ld, %d bytes sent\r\n", timestamp, rtc.getMillis(), zedBytesSent);
+                zedBytesSent = 0;
             }
             previousMilliseconds = currentMilliseconds;
         }
@@ -418,6 +421,7 @@ void ntripServerProcessRTCM(uint8_t incoming)
         {
             ntripServer->write(incoming); // Send this byte to socket
             ntripServerBytesSent++;
+            zedBytesSent++;
             ntripServerTimer = millis();
             netOutgoingRTCM = true;
         }


### PR DESCRIPTION
The left justified timestamp is displayed approximately once per second.

Data is delivered by the ZED to the ESP32 a byte at a time.

The "Tx RTCM" messages are printed after 5 milliesconds of idle time, trying to display transactions between the ZED and the ESP32.

The "NTRIP Server transmitted" messages are printed after 100 milliseconds of idle time, trying to display network packets that might be sent to the NTRIP server.

In the old behavior, several "Tx RTCM" messages were displayed and the value in the last message equaled the value in the "NTRIP Server transmitted" message.  This was confusing because the byte count grew with each "TX RTCM" message.

This commit adds the zedBytesSent value to count the bytes sent by the ZED to the ESP32.  The zedBytesSent value is displayed after 5 milliseconds of idle time and then reset to zero.  Totaling the "Tx RTCM" values between the "NTRIP Server transmitted" messages equals the value in the "NTRIP Server transmitted" message.  Another way to say this is: Totaling the bytes output by the ZED ("Tx RTCM") separated by 5 milliseconds of idle time equals the number of bytes ("NTRIP Server transmitted") separated by 100 milliseconds.