### PR TITLE
menuFirmware: Add automatic firmware update

### DIFF
--- a/Firmware/RTK_Surveyor/NVM.ino
+++ b/Firmware/RTK_Surveyor/NVM.ino
@@ -432,6 +432,11 @@ void recordSystemSettingsToFile(File *settingsFile)
     settingsFile->printf("%s=%d\r\n", "i2cInterruptsCore", settings.i2cInterruptsCore);
     settingsFile->printf("%s=%d\r\n", "rtcmTimeoutBeforeUsingLBand_s", settings.rtcmTimeoutBeforeUsingLBand_s);
 
+    // Automatic Firmware Update
+    settingsFile->printf("%s=%d\r\n", "autoFirmwareCheckMinutes", settings.autoFirmwareCheckMinutes);
+    settingsFile->printf("%s=%d\r\n", "debugFirmwareUpdate", settings.debugFirmwareUpdate);
+    settingsFile->printf("%s=%d\r\n", "enableAutoFirmwareUpdate", settings.enableAutoFirmwareUpdate);
+
     //Add new settings above
     //<------------------------------------------------------------>
 }
@@ -1334,6 +1339,14 @@ bool parseLine(char *str, Settings *settings)
         settings->printNetworkStatus = d;
     else if (strcmp(settingName, "rtcmTimeoutBeforeUsingLBand_s") == 0)
         settings->rtcmTimeoutBeforeUsingLBand_s = d;
+
+    // Automatic Firmware Update
+    else if (strcmp(settingName, "autoFirmwareCheckMinutes") == 0)
+        settings->autoFirmwareCheckMinutes = d;
+    else if (strcmp(settingName, "debugFirmwareUpdate") == 0)
+        settings->debugFirmwareUpdate = d;
+    else if (strcmp(settingName, "enableAutoFirmwareUpdate") == 0)
+        settings->enableAutoFirmwareUpdate = d;
 
     //Add new settings above
     //<------------------------------------------------------------>

--- a/Firmware/RTK_Surveyor/Network.ino
+++ b/Firmware/RTK_Surveyor/Network.ino
@@ -186,6 +186,7 @@ const char * const networkUser[] =
     "NTRIP Server",
     "PVT Client",
     "PVT Server",
+    "Firmware Update",
 };
 const int networkUserEntries = sizeof(networkUser) / sizeof(networkUser[0]);
 

--- a/Firmware/RTK_Surveyor/Network.ino
+++ b/Firmware/RTK_Surveyor/Network.ino
@@ -817,6 +817,12 @@ void networkStop(uint8_t networkType)
                 // Stop the network client
                 switch(user)
                 {
+                case NETWORK_USER_FIRMWARE_UPDATE:
+                    if (settings.debugNetworkLayer)
+                        systemPrintln("Network layer stopping firmware update");
+                    firmwareUpdateStop();
+                    break;
+
                 case NETWORK_USER_NTP_SERVER:
                     if (settings.debugNetworkLayer)
                         systemPrintln("Network layer stopping NTP server");

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -997,6 +997,9 @@ void loop()
     DMW_c("printPosition");
     printPosition(); // Periodically print GNSS coordinates if enabled
 
+    DMW_c("updateFirmware");
+    updateFirmware();
+
     // A small delay prevents panic if no other I2C or functions are called
     delay(10);
 }

--- a/Firmware/RTK_Surveyor/WiFi.ino
+++ b/Firmware/RTK_Surveyor/WiFi.ino
@@ -545,39 +545,39 @@ bool wifiConnect(unsigned long timeout)
 // This function is used to turn WiFi off if nothing needs it.
 bool wifiIsNeeded()
 {
-    bool needed = false;
-
     if (settings.enablePvtClient == true)
-        needed = true;
+        return true;
     if (settings.enablePvtServer == true)
-        needed = true;
+        return true;
+    if (online.firmwareUpdate)
+        return true;
 
     // Handle WiFi within systemStates
     if (systemState <= STATE_ROVER_RTK_FIX && settings.enableNtripClient == true)
-        needed = true;
+        return true;
 
     if (systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_FIXED_TRANSMITTING &&
         settings.enableNtripServer == true)
-        needed = true;
+        return true;
 
     // If the user has enabled NTRIP Client for an Assisted Survey-In, and Survey-In is running, keep WiFi on.
     if (systemState >= STATE_BASE_NOT_STARTED && systemState <= STATE_BASE_TEMP_SURVEY_STARTED &&
         settings.enableNtripClient == true && settings.fixedBase == false)
-        needed = true;
+        return true;
 
     // If WiFi is on while we are in the following states, allow WiFi to continue to operate
     if (systemState >= STATE_BUBBLE_LEVEL && systemState <= STATE_PROFILE)
     {
         // Keep WiFi on if user presses setup button, enters bubble level, is in AP config mode, etc
-        needed = true;
+        return true;
     }
 
     if (systemState == STATE_KEYS_WIFI_STARTED || systemState == STATE_KEYS_WIFI_CONNECTED)
-        needed = true;
+        return true;
     if (systemState == STATE_KEYS_PROVISION_WIFI_STARTED || systemState == STATE_KEYS_PROVISION_WIFI_CONNECTED)
-        needed = true;
+        return true;
 
-    return needed;
+    return false;
 }
 
 // Counts the number of entered SSIDs

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -16,6 +16,10 @@ void menuFirmware()
         getFirmwareVersion(currentVersion, sizeof(currentVersion), enableRCFirmware);
         systemPrintf("Current firmware: %s\r\n", currentVersion);
 
+        // Automatic firmware updates
+        systemPrintf("a) Automatic firmware updates: %s\r\n",
+                     settings.enableAutoFirmwareUpdate ? "Enabled" : "Disabled");
+
         if (strlen(reportedVersion) > 0)
         {
             if (newOTAFirmwareAvailable == false)
@@ -25,6 +29,9 @@ void menuFirmware()
             systemPrintln("c) Check SparkFun for device firmware");
 
         systemPrintf("e) Allow Beta Firmware: %s\r\n", enableRCFirmware ? "Enabled" : "Disabled");
+
+        systemPrintf("i) Automatic firmware check minutes: %d\r\n",
+                     settings.autoFirmwareCheckMinutes);
 
         if (newOTAFirmwareAvailable)
             systemPrintf("u) Update to new firmware: v%s\r\n", reportedVersion);
@@ -42,6 +49,10 @@ void menuFirmware()
             incoming--;
             updateFromSD(binFileNames[incoming]);
         }
+
+        else if (incoming == 'a')
+            settings.enableAutoFirmwareUpdate ^= 1;
+
         else if (incoming == 'c' && btPrintEcho == false)
         {
             if (wifiNetworkCount() == 0)
@@ -132,7 +143,28 @@ void menuFirmware()
             systemPrintln("Firmware update not available while configuration over Bluetooth is active");
             delay(2000);
         }
-        else if (newOTAFirmwareAvailable && incoming == 'u')
+
+        else if (incoming == 'e')
+        {
+            enableRCFirmware ^= 1;
+            strncpy(reportedVersion, "", sizeof(reportedVersion) - 1); // Reset to force c) menu
+        }
+
+        else if (incoming == 'i')
+        {
+            systemPrint("Enter minutes (1 - 999999) before next firmware check: ");
+            int minutes = getNumber(); // Returns EXIT, TIMEOUT, or long
+            if ((minutes != INPUT_RESPONSE_GETNUMBER_EXIT) &&
+                (minutes != INPUT_RESPONSE_GETNUMBER_TIMEOUT))
+            {
+                if ((minutes < 1) || (minutes > 999999))
+                    systemPrintln("Error: Out of range (1 - 999999)");
+                else
+                    settings.autoFirmwareCheckMinutes = minutes;
+            }
+        }
+
+        else if ((incoming == 'u') && newOTAFirmwareAvailable)
         {
             bool previouslyConnected = wifiIsConnected();
 
@@ -144,11 +176,6 @@ void menuFirmware()
                 WIFI_STOP();
         }
 
-        else if (incoming == 'e')
-        {
-            enableRCFirmware ^= 1;
-            strncpy(reportedVersion, "", sizeof(reportedVersion) - 1); // Reset to force c) menu
-        }
         else if (incoming == 'x')
             break;
         else if (incoming == INPUT_RESPONSE_GETCHARACTERNUMBER_EMPTY)

--- a/Firmware/RTK_Surveyor/menuFirmware.ino
+++ b/Firmware/RTK_Surveyor/menuFirmware.ino
@@ -1,3 +1,27 @@
+/*------------------------------------------------------------------------------
+menuFirmware.ino
+
+  This module implements the firmware menu and update code.
+------------------------------------------------------------------------------*/
+//----------------------------------------
+// Constants
+//----------------------------------------
+
+const char * const firmwareUpdateStateNames[] =
+{
+    "UPDATE_STATE_OFF",
+    "UPDATE_STATE_START_WIFI",
+    "UPDATE_STATE_WAIT_FOR_WIFI",
+    "UPDATE_STATE_GET_FIRMWARE_VERSION",
+    "UPDATE_STATE_CHECK_FIRMWARE_VERSION",
+    "UPDATE_STATE_UPDATE_FIRMWARE",
+};
+const int firmwareUpdateStateEntries = sizeof(firmwareUpdateStateNames) / sizeof(firmwareUpdateStateNames[0]);
+
+//----------------------------------------
+// Menu
+//----------------------------------------
+
 // Update firmware if bin files found
 void menuFirmware()
 {
@@ -188,6 +212,10 @@ void menuFirmware()
 
     clearBuffer(); // Empty buffer of any newline chars
 }
+
+//----------------------------------------
+// Firmware update code
+//----------------------------------------
 
 void mountSDThenUpdate(const char *firmwareFileName)
 {
@@ -815,4 +843,12 @@ int mapMonthName(char *mmm)
             return i + 1;
     }
     return -1;
+}
+
+// Verify the firmware update tables
+void firmwareUpdateVerifyTables()
+{
+    // Verify the table lengths
+    if (firmwareUpdateStateEntries != UPDATE_STATE_MAX)
+        reportFatalError("Fix firmwareUpdateStateNames table to match FirmwareUpdateState");
 }

--- a/Firmware/RTK_Surveyor/menuSystem.ino
+++ b/Firmware/RTK_Surveyor/menuSystem.ino
@@ -638,6 +638,10 @@ void menuDebugSoftware()
         else
             systemPrintln("Disabled");
 
+        // Automatic Firmware Update
+        systemPrintf("60) Print firmware update states: %s\r\n",
+                     settings.debugFirmwareUpdate ? "Enabled" : "Disabled");
+
         systemPrintln("e) Erase LittleFS");
 
         systemPrintln("r) Force system reset");
@@ -697,6 +701,8 @@ void menuDebugSoftware()
         }
         else if (incoming == 50)
             settings.enableTaskReports ^= 1;
+        else if (incoming == 60)
+            settings.debugFirmwareUpdate ^= 1;
         else if (incoming == 'e')
         {
             systemPrintln("Erasing LittleFS and resetting");

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -1062,6 +1062,11 @@ typedef struct
 
     uint8_t rtcmTimeoutBeforeUsingLBand_s = 10; //If 10s have passed without RTCM, enable PMP corrections over L-Band if available
 
+    // Automatic Firmware Update
+    bool debugFirmwareUpdate = false;
+    bool enableAutoFirmwareUpdate = false;
+    uint32_t autoFirmwareCheckMinutes = 24 * 60;
+
     //Add new settings above
     //<------------------------------------------------------------>
 

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -183,6 +183,7 @@ enum NetworkUsers
     NETWORK_USER_NTRIP_SERVER,     // NTRIP server
     NETWORK_USER_PVT_CLIENT,       // PVT client
     NETWORK_USER_PVT_SERVER,       // PVT server
+    NETWORK_USER_FIRMWARE_UPDATE,  // Firmware update
     // Last network user
     NETWORK_USER_MAX
 };
@@ -493,6 +494,20 @@ enum PeriodDisplayValues
 #define PERIODIC_CLEAR(x) periodicDisplay &= ~PERIODIC_MASK(x)
 #define PERIODIC_SETTING(x) (settings.periodicDisplay & PERIODIC_MASK(x))
 #define PERIODIC_TOGGLE(x) settings.periodicDisplay ^= PERIODIC_MASK(x)
+
+// Automatic firmware update support
+typedef enum
+{
+    //34567890123456789012345678901234567890
+    UPDATE_STATE_OFF = 0,
+    UPDATE_STATE_START_WIFI,
+    UPDATE_STATE_WAIT_FOR_WIFI,
+    UPDATE_STATE_GET_FIRMWARE_VERSION,
+    UPDATE_STATE_CHECK_FIRMWARE_VERSION,
+    UPDATE_STATE_UPDATE_FIRMWARE,
+    // Add new states here
+    UPDATE_STATE_MAX
+} FirmwareUpdateState;
 
 // These are the allowable messages to broadcast and log (if enabled)
 
@@ -1094,6 +1109,7 @@ struct struct_online
     bool pvtServer = false;
     ethernetStatus_e ethernetStatus = ETH_NOT_STARTED;
     bool NTPServer = false; // EthernetUDP
+    bool firmwareUpdate = false;
 } online;
 
 #ifdef COMPILE_WIFI

--- a/Firmware/RTK_Surveyor/support.ino
+++ b/Firmware/RTK_Surveyor/support.ino
@@ -1166,6 +1166,7 @@ void verifyTables ()
 {
     // Verify the consistency of the internal tables
     ethernetVerifyTables();
+    firmwareUpdateVerifyTables();
     networkVerifyTables();
     ntpValidateTables();
     ntripClientValidateTables();


### PR DESCRIPTION
Automatic firmware updates uses WiFi to check the SparkFun firmware release site for a new version of the released firmware.  An update occurs when:

* The current version of the firmware is less than the version on the SparkFun site
* The current version is a debug version (starts with 'd')
* The current version was build locally (major version 99)

Enabling automatic firmware updates:
    
1. Enter the serial menu system
2. Type 'f' to enter the firmware menu
3. Type 'i' to set the firmware update interval
4. Specify the interval in minutes
5. Type 'a' to enable the automatic firmware updates
6. Type 'x' to exit the firmware menu
7. Type 'x' to exit and return to normal operation
    
The RTK will then check for firmware updates after the interval has expired.
