### PR TITLE
Network clients start and stop depending upon operating modes

### DIFF
--- a/Firmware/RTK_Surveyor/Developer.ino
+++ b/Firmware/RTK_Surveyor/Developer.ino
@@ -50,10 +50,6 @@ void networkVerifyTables() {}
 //----------------------------------------
 
 void ntripClientPrintStatus() {systemPrint("NTRIP Client not compiled");}
-void ntripClientStart()
-{
-    systemPrintln("NTRIP Client not available: Ethernet and WiFi not compiled");
-}
 void ntripClientStop(bool clientAllocated) {online.ntripClient = false;}
 void ntripClientUpdate() {}
 void ntripClientValidateTables() {}
@@ -65,10 +61,6 @@ void ntripClientValidateTables() {}
 bool ntripServerIsCasting() {return false;}
 void ntripServerPrintStatus() {systemPrint("NTRIP Server not compiled");}
 void ntripServerProcessRTCM(uint8_t incoming) {}
-void ntripServerStart()
-{
-    systemPrintln("NTRIP Server not available: Ethernet and WiFi not compiled");
-}
 void ntripServerStop(bool clientAllocated) {online.ntripServer = false;}
 void ntripServerUpdate() {}
 void ntripServerValidateTables() {}

--- a/Firmware/RTK_Surveyor/Network.ino
+++ b/Firmware/RTK_Surveyor/Network.ino
@@ -1160,17 +1160,14 @@ void networkUpdate()
     if (PERIODIC_DISPLAY(PD_NETWORK_STATE))
         PERIODIC_CLEAR(PD_NETWORK_STATE);
 
-    // Skip updates if in configure-via-ethernet mode
-    if (!configureViaEthernet)
-    {
-        ntpServerUpdate();   // Process any received NTP requests
-        ntripClientUpdate(); // Check the NTRIP client connection and move data NTRIP --> ZED
-        ntripServerUpdate(); // Check the NTRIP server connection and move data ZED --> NTRIP
-        otaClientUpdate();   // Perform automatic over-the-air firmware updates
-        pvtClientUpdate();   // Turn on the PVT client as needed
-        pvtServerUpdate();   // Turn on the PVT server as needed
-        pvtUdpServerUpdate();   // Turn on the PVT UDP server as needed
-    }
+    // Update the network services
+    ntpServerUpdate();   // Process any received NTP requests
+    ntripClientUpdate(); // Check the NTRIP client connection and move data NTRIP --> ZED
+    ntripServerUpdate(); // Check the NTRIP server connection and move data ZED --> NTRIP
+    otaClientUpdate();   // Perform automatic over-the-air firmware updates
+    pvtClientUpdate();   // Turn on the PVT client as needed
+    pvtServerUpdate();   // Turn on the PVT server as needed
+    pvtUdpServerUpdate();   // Turn on the PVT UDP server as needed
 
     // Display the IP addresses
     networkPeriodicallyDisplayIpAddress();

--- a/Firmware/RTK_Surveyor/RTK_Surveyor.ino
+++ b/Firmware/RTK_Surveyor/RTK_Surveyor.ino
@@ -701,6 +701,8 @@ volatile PeriodicDisplay_t periodicDisplay;
 
 unsigned long shutdownNoChargeTimer = 0;
 
+RtkMode_t rtkMode; // Mode of operation
+
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 #define DEAD_MAN_WALKING_ENABLED    0

--- a/Firmware/RTK_Surveyor/States.ino
+++ b/Firmware/RTK_Surveyor/States.ino
@@ -87,6 +87,7 @@ void updateSystemState()
 
         */
         case (STATE_ROVER_NOT_STARTED): {
+            RTK_MODE(RTK_MODE_ROVER);
             if (online.gnss == false)
             {
                 firstRoverStart = false; // If GNSS is offline, we still need to allow button use
@@ -120,6 +121,7 @@ void updateSystemState()
 
             setMuxport(settings.dataPortChannel); // Return mux to original channel
 
+            networkStop(NETWORK_TYPE_WIFI);
             WIFI_STOP();      // Stop WiFi, ntripClient will start as needed.
             bluetoothStart(); // Turn on Bluetooth with 'Rover' name
             radioStart();     // Start internal radio if enabled, otherwise disable
@@ -134,7 +136,6 @@ void updateSystemState()
 
                 displayRoverSuccess(500);
 
-                ntripClientStart();
                 changeState(STATE_ROVER_NO_FIX);
 
                 firstRoverStart = false; // Do not allow entry into test menu again
@@ -227,6 +228,7 @@ void updateSystemState()
             */
 
         case (STATE_BASE_NOT_STARTED): {
+            RTK_MODE(RTK_MODE_BASE_SURVEY_IN);
             firstRoverStart = false; // If base is starting, no test menu, normal button use.
 
             if (online.gnss == false)
@@ -249,7 +251,10 @@ void updateSystemState()
 
             // Allow WiFi to continue running if NTRIP Client is needed for assisted survey in
             if (wifiIsNeeded() == false)
+            {
+                networkStop(NETWORK_TYPE_WIFI);
                 WIFI_STOP();
+            }
 
             bluetoothStop();
             bluetoothStart(); // Restart Bluetooth with 'Base' identifier
@@ -328,8 +333,7 @@ void updateSystemState()
                     digitalWrite(pin_baseStatusLED, HIGH); // Indicate survey complete
 
                 // Start the NTRIP server if requested
-                if (settings.enableNtripServer == true)
-                    ntripServerStart();
+                RTK_MODE(RTK_MODE_BASE_FIXED);
 
                 radioStart(); // Start internal radio if enabled, otherwise disable
 
@@ -396,15 +400,12 @@ void updateSystemState()
         // User has set switch to base with fixed option enabled. Let's configure and try to get there.
         // If fixed base fails, we'll handle it here
         case (STATE_BASE_FIXED_NOT_STARTED): {
+            RTK_MODE(RTK_MODE_BASE_FIXED);
             bool response = startFixedBase();
             if (response == true)
             {
                 if ((productVariant == RTK_SURVEYOR) || (productVariant == REFERENCE_STATION))
                     digitalWrite(pin_baseStatusLED, HIGH); // Turn on base LED
-
-                // Start the NTRIP server if requested
-                if (settings.enableNtripServer)
-                    ntripServerStart();
 
                 radioStart(); // Start internal radio if enabled, otherwise disable
 
@@ -614,6 +615,8 @@ void updateSystemState()
             {
                 forceSystemStateUpdate = true; // Imediately go to this new state
                 changeState(setupState);       // Change to last setup state
+                if (setupState == STATE_BUBBLE_LEVEL)
+                    RTK_MODE(RTK_MODE_BUBBLE_LEVEL);
             }
         }
         break;
@@ -643,7 +646,10 @@ void updateSystemState()
             if (!startWebServer()) // Start in AP mode and show config html page
                 changeState(STATE_ROVER_NOT_STARTED);
             else
+            {
+                RTK_MODE(RTK_MODE_WIFI_CONFIG);
                 changeState(STATE_WIFI_CONFIG);
+            }
         }
         break;
 
@@ -707,6 +713,7 @@ void updateSystemState()
                 theGNSS.addCfgValset(UBLOX_CFG_MSGOUT_RTCM_3X_TYPE1230_UART2, 1); // Enable message 1230 every second
                 theGNSS.sendCfgValset();                                          // Send the VALSET
 
+                RTK_MODE(RTK_MODE_TESTING);
                 changeState(STATE_TESTING);
             }
         }
@@ -988,6 +995,7 @@ void updateSystemState()
 
 #ifdef COMPILE_ETHERNET
         case (STATE_NTPSERVER_NOT_STARTED): {
+            RTK_MODE(RTK_MODE_NTP);
             firstRoverStart = false; // If NTP is starting, no test menu, normal button use.
 
             if (online.gnss == false)
@@ -1056,6 +1064,7 @@ void updateSystemState()
         break;
 
         case (STATE_CONFIG_VIA_ETH_STARTED): {
+            RTK_MODE(RTK_MODE_ETHERNET_CONFIG);
             // The code should only be able to enter this state if configureViaEthernet is true.
             // If configureViaEthernet is not true, we need to restart again.
             //(If we continue, startEthernerWebServerESP32W5500 will fail as it won't have exclusive access to SPI and

--- a/Firmware/RTK_Surveyor/settings.h
+++ b/Firmware/RTK_Surveyor/settings.h
@@ -54,6 +54,23 @@ bool newSystemStateRequested = false;
 // When user pauses for X amount of time, system will enter that state
 SystemState setupState = STATE_MARK_EVENT;
 
+// Base modes set with RTK_MODE
+#define RTK_MODE_BASE_FIXED         0x0001
+#define RTK_MODE_BASE_SURVEY_IN     0x0002
+#define RTK_MODE_BUBBLE_LEVEL       0x0004
+#define RTK_MODE_ETHERNET_CONFIG    0x0008
+#define RTK_MODE_NTP                0x0010
+#define RTK_MODE_ROVER              0x0020
+#define RTK_MODE_TESTING            0x0040
+#define RTK_MODE_WIFI_CONFIG        0x0080
+
+typedef uint8_t RtkMode_t;
+
+#define RTK_MODE(mode)          rtkMode = mode;
+
+#define EQ_RTK_MODE(mode)       (rtkMode && (rtkMode == (mode & rtkMode)))
+#define NEQ_RTK_MODE(mode)      (rtkMode && (rtkMode != (mode & rtkMode)))
+
 typedef enum
 {
     RTK_SURVEYOR = 0,


### PR DESCRIPTION
Define the RTK operating modes and set these modes in States.ino.

For each network user:
* Add a bit mask specifying which modes the network user is active
* Stop the network user when the enable or mode changes
* Start the network user when the mode and enable are set