### PR TITLE
Increase the RTCM transmit timeout from 3 seconds to 15 seconds

### DIFF
--- a/Firmware/RTK_Surveyor/NtripServer.ino
+++ b/Firmware/RTK_Surveyor/NtripServer.ino
@@ -757,7 +757,7 @@ void ntripServerUpdate()
             systemPrintln("Connection to NTRIP Caster was lost");
             ntripServerRestart();
         }
-        else if ((millis() - ntripServerTimer) > (3 * 1000))
+        else if ((millis() - ntripServerTimer) > (15 * 1000))
         {
             // GNSS stopped sending RTCM correction data
             systemPrintln("NTRIP Server breaking connection to caster due to lack of RTCM data!");


### PR DESCRIPTION
Allows NTRIP server connection failures to occur without breaking the NTRIP server connection to another server.