### PR TITLE
Fix wrong survey-in time limit in help text

### DIFF
--- a/Firmware/RTK_Surveyor/AP-Config/index.html
+++ b/Firmware/RTK_Surveyor/AP-Config/index.html
@@ -488,7 +488,7 @@
                         <input type="radio" id="baseTypeSurveyIn" name="baseType" class="form-radio" checked>
                         <label for="baseTypeSurveyIn">Survey-In</label>
                         <span class="tt" data-bs-placement="right"
-                            title="If the precise location of a base station is not known it may be obtained by ‘surveying’ the location. The base is fixed in one place and takes approximately 60 seconds worth of readings to obtain a best fit location based on the measurements. This method achieves ~30cm accurate position but can vary. Increasing the Minimum Observation Time and/or Required Mean Deviation will increase accuracy but only to a point. Better accuracy is achieved with long-term logging and post processing. Default: 60s and 5.0m. Limits: 60 to 900s, 1.0 to 5.0m.">
+                            title="If the precise location of a base station is not known it may be obtained by ‘surveying’ the location. The base is fixed in one place and takes approximately 60 seconds worth of readings to obtain a best fit location based on the measurements. This method achieves ~30cm accurate position but can vary. Increasing the Minimum Observation Time and/or Required Mean Deviation will increase accuracy but only to a point. Better accuracy is achieved with long-term logging and post processing. Default: 60s and 5.0m. Limits: 60 to 600s, 1.0 to 5.0m.">
                             <span class="icon-info-circle text-primary ms-2"></span>
                         </span>
                     </div>


### PR DESCRIPTION
Reference station doesn't accept values above 600 seconds for survey-in while the help text suggests values up to and including 900 seconds are acceptable.