### PR TITLE
Clarify docs: TCP server, radio UART

### DIFF
--- a/docs/menu_ports.md
+++ b/docs/menu_ports.md
@@ -14,6 +14,8 @@ Surveyor: ![Feature Partially Supported](img/Icons/YellowDot.png) / Express: ![F
 
 By default, the **Radio** port is set to 57600bps to match the [Serial Telemetry Radios](https://www.sparkfun.com/products/19032) that are recommended to be used with the RTK Facet (it is a plug-and-play solution). This can be set from 4800bps to 921600bps.
 
+The radio port is connected to the F9P's UART2.
+
 ## Mux Channel
 
 The **Data** port on the RTK Facet, Express, and Express Plus is very flexible. Internally the **Data** connector is connected to a digital mux allowing one of four software-selectable setups. By default, the Data port will be connected to the UART1 of the ZED-F9P and output any messages via serial.

--- a/docs/menu_tcp_udp.md
+++ b/docs/menu_tcp_udp.md
@@ -2,13 +2,16 @@
 
 Surveyor: ![Feature Supported](img/Icons/GreenDot.png) / Express: ![Feature Supported](img/Icons/GreenDot.png) / Express Plus: ![Feature Supported](img/Icons/GreenDot.png) / Facet: ![Feature Supported](img/Icons/GreenDot.png) / Facet L-Band: ![Feature Supported](img/Icons/GreenDot.png) / Reference Station: ![Feature Supported](img/Icons/GreenDot.png)
 
-![PVT Client and Server settings](<img/Terminal/SparkFun RTK Network Menu.png>)
+![Client and Server settings](<img/Terminal/SparkFun RTK Network Menu.png>)
 
-*PVT Client and Server settings*
+*Client and Server settings*
 
-## PVT Client and Server
+As an alternative to serial ports, serial over USB, or Bluetooth, the RTK device can send and receive GNSS data over TCP, and can send data over UDP.   These mechanisms sit on top of the network layer (WiFi or Ethernet).  The data could be NMEA, UBX, RTCM, and is the same data that would be sent and received over Bluetooth.  The mechanism can be used in Rover or Base mode.  There are three mechanisms, two TCP and one UDP, described below.
 
-The RTK device supports connection over TCP (aka PVT Client and Server). The TCP Client sits on top of the network layer (WiFi or Ethernet) and sends position data to one or more computers or cell phones for display. Some Data Collector software (such as [Vespucci](gis_software.md#vespucci)) requires that the SparkFun RTK device connect as a TCP Client. Other software (such as [QGIS](gis_software.md#qgis)) requires that the SparkFun RTK device acts as a TCP Server. Both are supported.
+## TCP Client and Server
+
+Configuring a TCP Client will cause the RTK device to open a TCP connection to a given address and port, and then send and receive data.  Configuring a TCP Server will cause the RTK device to listen on the given port for an incoming connection.  In either case, when a connection is established the device will send and receive data.
+Some Data Collector software (such as [Vespucci](gis_software.md#vespucci)) requires that the SparkFun RTK device connect as a TCP Client. Other software (such as [QGIS](gis_software.md#qgis)) requires that the SparkFun RTK device acts as a TCP Server. Both are supported.
 
 **Note:** Currently for WiFi: TCP is only supported while connected to local WiFi, not AP mode. This means the device will need to be connected to a WiFi network, such as a mobile hotspot, before TCP connections can occur.
 
@@ -22,4 +25,4 @@ The above animation was generated using [TCP_Server.py](https://github.com/spark
 
 ## UDP Server
 
-NMEA messages can also be broadcast via UDP on Ethernet and WiFi, rather than TCP. If enabled, the UDP Server will begin broadcasting NMEA data over the specific port (default 10110).
+Data can also be broadcast via UDP on Ethernet and WiFi, rather than TCP. If enabled, the UDP Server will begin broadcasting NMEA data over the specific port (default 10110).


### PR DESCRIPTION
This PR contains two commits, each documented in its commit message.

The first clarifies the TCP server feature.  The second notes which UART the data port is connected to.
Thanks to forum users for help understanding.