### PR TITLE
make log message match L-band disable function name

### DIFF
--- a/Firmware/RTK_Surveyor/ZED.ino
+++ b/Firmware/RTK_Surveyor/ZED.ino
@@ -97,7 +97,7 @@ bool zedDisableLBandCommunication()
     }
     else
     {
-        systemPrintln("zedEnableLBandCorrections: Unknown platform");
+        systemPrintln("zedDisableLBandCorrections: Unknown platform");
         return (false);
     }
 


### PR DESCRIPTION
fix a simple copy-paste error.  Makes debugging easier.