### PR TITLE
simplify L-band console message logic

### DIFF
--- a/Firmware/RTK_Surveyor/menuGNSS.ino
+++ b/Firmware/RTK_Surveyor/menuGNSS.ino
@@ -471,6 +471,5 @@ void printZEDInfo()
 // Print the NEO firmware version
 void printNEOInfo()
 {
-    if (productVariant == RTK_FACET_LBAND || productVariant == RTK_FACET_LBAND_DIRECT)
-        systemPrintf("NEO-D9S firmware: %s\r\n", neoFirmwareVersion);
+    systemPrintf("NEO-D9S firmware: %s\r\n", neoFirmwareVersion);
 }


### PR DESCRIPTION
Might have been a left-over from a previous refactor of platform detection.  Both callers already detect if L-band is online.

This was needed for a custom hardware platform but is equally applicable to SparkFun units.