### PR TITLE
Describe WiFi configuration as choice betwen AP and STA

### DIFF
--- a/Firmware/RTK_Surveyor/AP-Config/index.html
+++ b/Firmware/RTK_Surveyor/AP-Config/index.html
@@ -1351,11 +1351,11 @@
                     <div id="wifiConfigTypeDropdown" class="mt-3">
                         <label for="wifiConfigType">Configure Mode: </label>
                         <select name="wifiConfigType" id="wifiConfigOverAP" class="form-dropdown">
-                            <option value="1">AP</option>
-                            <option value="0">WiFi</option>
+                            <option value="1">Access Point</option>
+                            <option value="0">Station Client</option>
                         </select>
                         <span class="tt" data-bs-placement="right"
-                            title="In AP mode, the device will broadcast as an access point called RTK-Config. In WiFi mode, the device will connect to local WiFi and be configurable on the displayed IP address.">
+                            title="Access Point mode broadcasts SSID &quot;RTK-Config&quot;. Station Client mode connects to the configured SSID.">
                             <span class="icon-info-circle text-primary ms-2"></span>
                         </span>
                     </div>

--- a/Firmware/RTK_Surveyor/WiFi.ino
+++ b/Firmware/RTK_Surveyor/WiFi.ino
@@ -83,8 +83,8 @@ void menuWiFi()
             systemPrintf("%d) Password %d: %s\r\n", (x * 2) + 2, x + 1, settings.wifiNetworks[x].password);
         }
 
-        systemPrint("a) Configure device via WiFi Access Point or connect to WiFi: ");
-        systemPrintf("%s\r\n", settings.wifiConfigOverAP ? "AP" : "WiFi");
+        systemPrint("a) Configure device WiFi as Access Point or Station Client: ");
+        systemPrintf("%s\r\n", settings.wifiConfigOverAP ? "AP" : "STA");
 
         systemPrint("c) Captive Portal: ");
         systemPrintf("%s\r\n", settings.enableCaptivePortal ? "Enabled" : "Disabled");


### PR DESCRIPTION
Improve readability of WiFi configuration by using industry standard terminology AP and STA.

It is very confusing before this change to understand from what perspective the description refers to, see #785 which I agree is similar to my recent experience. Let's use industry standard terminology and make this clear to understand.